### PR TITLE
feat: Optionally hide untracked files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require'diffview'.setup {
 
 ## Usage
 
-### `:DiffviewOpen [git rev] [ -- {paths...}]`
+### `:DiffviewOpen [git rev] [args] [ -- {paths...}]`
 
 Calling `:DiffviewOpen` with no args opens a new Diffview that compares against
 `HEAD`. You can also provide any valid git rev to view only changes for that
@@ -82,11 +82,15 @@ You can also provide additional paths to narrow down what files are shown:
 
 - `:DiffviewOpen HEAD~2 -- lua/diffview plugin`
 
+For information about additional `[args]`, visit the [documentation](https://github.com/sindrets/diffview.nvim/blob/main/doc/diffview.txt).
+
 Additional commands for convenience:
 
 - `:DiffviewClose`: Close the current diffview. You can also use `:tabclose`.
 - `:DiffviewToggleFiles`: Toggle the files panel.
 - `:DiffviewFocusFiles`: Bring focus to the files panel.
+- `:DiffviewRefresh`: Update stats and entries in the file list of the current
+  Diffview.
 
 With a Diffview open and the default key bindings, you can cycle through changed
 files with `<tab>` and `<s-tab>` (see configuration to change the key bindings).

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -70,7 +70,7 @@ Example configuration with default settings:
 COMMANDS                                            *diffview-nvim-commands*
 
                                                         *:DiffviewOpen*
-:DiffviewOpen [git-rev] [ -- {paths...}]
+:DiffviewOpen [git-rev] [args] [ -- {paths...}]
                         Opens a new Diffview that compares against [git-rev]. If
                         no [git-rev] is given, defaults to `HEAD`. Additional
                         {paths...} can be provided to narrow down what files are
@@ -82,7 +82,16 @@ COMMANDS                                            *diffview-nvim-commands*
         :DiffviewOpen d4a7b0d
         :DiffviewOpen d4a7b0d..519b30e
         :DiffviewOpen HEAD~2 -- lua/diffview plugin
+        :DiffviewOpen d4a7b0d -uno
 <
+    Args:
+        -u[value], --untracked-files[={value}]
+                        Specify whether or not to show untracked files. If
+                        flag is given without value; defaults to `true`.
+                        {value} can be one of:
+                          - `true`, `normal`, `all` Show untracked.
+                          - `false`, `no` Don't show untracked.
+
                                                         *:DiffviewClose*
 :DiffviewClose          Close the active Diffview.
 

--- a/lua/diffview/arg-parser.lua
+++ b/lua/diffview/arg-parser.lua
@@ -1,0 +1,82 @@
+local M = {}
+
+local short_flag_pat = "^%-(%a)=?(.*)"
+local long_flag_pat = "^%-%-(%a[%a%d-]*)=?(.*)"
+
+---@class ArgObject
+---@field flags table<string, string>
+---@field args string[]
+---@field post_args string[]
+local ArgObject = {}
+ArgObject.__index = ArgObject
+
+---ArgObject constructor.
+---@param flags table<string, string>
+---@param args string[]
+---@return ArgObject
+function ArgObject:new(flags, args, post_args)
+  local this = {
+    flags = flags,
+    args = args,
+    post_args = post_args
+  }
+  setmetatable(this, self)
+  return this
+end
+
+---Get a flag value.
+---@vararg ... string[] Flag synonyms
+---@return any
+function ArgObject:get_flag(...)
+  for _, name in ipairs({...}) do
+    if self.flags[name] ~= nil then return self.flags[name] end
+  end
+end
+
+---Parse args and create an ArgObject.
+---@param args string[]
+---@return ArgObject
+function M.parse(args)
+  local flags = {}
+  local pre_args = {}
+  local post_args = {}
+
+  for i, arg in ipairs(args) do
+    if arg == "--" then
+      for j = i + 1, #args do
+        table.insert(post_args, args[j])
+      end
+      break
+    end
+
+    local flag, value
+    flag, value = arg:match(short_flag_pat)
+    if flag then
+      value = (value == "") and "true" or value
+      flags[flag] = value
+      goto continue
+    end
+
+    flag, value = arg:match(long_flag_pat)
+    if flag then
+      value = (value == "") and "true" or value
+      flags[flag] = value
+      goto continue
+    end
+
+    table.insert(pre_args, arg)
+
+    ::continue::
+  end
+
+  return ArgObject:new(flags, pre_args, post_args)
+end
+
+function M.ambiguous_bool(value, default, truthy, falsy)
+  if vim.tbl_contains(truthy, value) then return true end
+  if vim.tbl_contains(falsy, value) then return false end
+  return default
+end
+
+M.ArgObject = ArgObject
+return M

--- a/lua/diffview/git.lua
+++ b/lua/diffview/git.lua
@@ -9,8 +9,9 @@ local M = {}
 ---@param left Rev
 ---@param right Rev
 ---@param path_args string[]|nil
+---@param options ViewOptions
 ---@return FileEntry[]
-function M.diff_file_list(git_root, left, right, path_args)
+function M.diff_file_list(git_root, left, right, path_args, options)
   local files = {}
 
   local p_args = ""
@@ -59,9 +60,10 @@ function M.diff_file_list(git_root, left, right, path_args)
     end
   end
 
-  -- If one of the revs are LOCAL and `status.showUntrackedFiles` is not set to
-  -- `false`, include untracked files.
-  if M.has_local(left, right) and M.show_untracked(git_root) then
+  local show_untracked = options.show_untracked
+  if show_untracked == nil then show_untracked = M.show_untracked(git_root) end
+
+  if show_untracked and M.has_local(left, right) then
     cmd = "git -C " .. vim.fn.shellescape(git_root) .. " ls-files --others --exclude-standard"
     local untracked = vim.fn.systemlist(cmd)
 

--- a/lua/diffview/view.lua
+++ b/lua/diffview/view.lua
@@ -14,12 +14,16 @@ local win_reset_opts = {
   scrollbind = false
 }
 
+---@class ViewOptions
+---@field show_untracked boolean|nil
+
 ---@class View
 ---@field tabpage integer
 ---@field git_root string
 ---@field path_args string[]
 ---@field left Rev
 ---@field right Rev
+---@field options ViewOptions
 ---@field file_panel FilePanel
 ---@field left_winid integer
 ---@field right_winid integer
@@ -38,7 +42,8 @@ function View:new(opt)
     path_args = opt.path_args,
     left = opt.left,
     right = opt.right,
-    files = git.diff_file_list(opt.git_root, opt.left, opt.right, opt.path_args),
+    options = opt.options,
+    files = git.diff_file_list(opt.git_root, opt.left, opt.right, opt.path_args, opt.options),
     file_idx = 1,
     nulled = false,
     ready = false
@@ -154,7 +159,9 @@ function View:update_files()
     end
   end
 
-  local new_files = git.diff_file_list(self.git_root, self.left, self.right, self.path_args)
+  local new_files = git.diff_file_list(
+    self.git_root, self.left, self.right, self.path_args, self.options
+  )
   local diff = Diff:new(self.files, new_files, function (aa, bb)
     return aa.path == bb.path
   end)


### PR DESCRIPTION
Fixes #10.

This adds an optional arg to either enable or disable showing untracked files. If you provide this flag, Diffview will ignore your local setting for `status.showUntrackedFiles`.

```
:DiffviewOpen [git-rev] [args] [ -- {paths...}]
    ...
    Args:
        -u[value], --untracked-files[={value}]
                        Specify whether or not to show untracked files. If
                        flag is given without value; defaults to `true`.
                        {value} can be one of:
                          - `true`, `normal`, `all` Show untracked.
                          - `false`, `no` Don't show untracked.
```

Example usage:

```
:DiffviewOpen HEAD~2 -uno
:DiffviewOpen HEAD~2 --untracked-files=all
```