### PR TITLE
feat: Custom completion for `:DiffviewOpen`

### DIFF
--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -2,6 +2,7 @@ local arg_parser = require'diffview.arg-parser'
 local lib = require'diffview.lib'
 local config = require'diffview.config'
 local colors = require'diffview.colors'
+local utils = require "diffview.utils"
 local M = {}
 
 local flag_value_completion = arg_parser.FlagValueMap:new()
@@ -15,8 +16,8 @@ function M.init()
   colors.setup()
 end
 
-function M.open(args)
-  local view = lib.parse_revs(args)
+function M.open(...)
+  local view = lib.parse_revs(utils.tbl_pack(...))
   if view then
     view:open()
   end

--- a/lua/diffview/arg-parser.lua
+++ b/lua/diffview/arg-parser.lua
@@ -86,7 +86,7 @@ function FlagValueMap:get_all_names()
 end
 
 function FlagValueMap:get_completion(flag_name)
-  local is_short = flag_name:match(short_flag_pat)
+  local is_short = flag_name:match(short_flag_pat) ~= nil
   if is_short then
     flag_name = flag_name:sub(1,2)
   else

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -173,6 +173,14 @@ function M.tbl_deep_clone(t)
   return clone
 end
 
+function M.tbl_pack(...)
+  return {n=select('#',...); ...}
+end
+
+function M.tbl_unpack(t, i, j)
+  return unpack(t, i or 1, j or t.n or #t)
+end
+
 function M.find_named_buffer(name)
   for _, v in ipairs(api.nvim_list_bufs()) do
     if vim.fn.bufname(v) == name then

--- a/plugin/diffview.vim
+++ b/plugin/diffview.vim
@@ -1,6 +1,6 @@
 if !has('nvim-0.5') || exists('g:diffview_nvim_loaded') | finish | endif
 
-command! -complete=customlist,s:completion -nargs=* DiffviewOpen call s:diffview_open(<f-args>)
+command! -complete=customlist,s:completion -nargs=* DiffviewOpen lua require'diffview'.open(<f-args>)
 command! -nargs=0 DiffviewClose lua require'diffview'.close()
 command! -nargs=0 DiffviewFocusFiles lua require'diffview'.on_keypress("focus_files")
 command! -nargs=0 DiffviewToggleFiles lua require'diffview'.on_keypress("toggle_files")
@@ -11,7 +11,10 @@ function s:diffview_open(...)
 endfunction
 
 function s:completion(argLead, cmdLine, curPos)
-    return luaeval("require'diffview'.completion(vim.fn.eval('a:argLead'), vim.fn.eval('a:cmdLine'), vim.fn.eval('a:curPos'))")
+    return luaeval("require'diffview'.completion("
+                \ . "vim.fn.eval('a:argLead'),"
+                \ . "vim.fn.eval('a:cmdLine'),"
+                \ . "vim.fn.eval('a:curPos'))")
 endfunction
 
 augroup Diffview

--- a/plugin/diffview.vim
+++ b/plugin/diffview.vim
@@ -1,6 +1,6 @@
 if !has('nvim-0.5') || exists('g:diffview_nvim_loaded') | finish | endif
 
-command! -nargs=* DiffviewOpen call s:diffview_open(<f-args>)
+command! -complete=customlist,s:completion -nargs=* DiffviewOpen call s:diffview_open(<f-args>)
 command! -nargs=0 DiffviewClose lua require'diffview'.close()
 command! -nargs=0 DiffviewFocusFiles lua require'diffview'.on_keypress("focus_files")
 command! -nargs=0 DiffviewToggleFiles lua require'diffview'.on_keypress("toggle_files")
@@ -8,6 +8,10 @@ command! -nargs=0 DiffviewRefresh lua require'diffview'.on_keypress("refresh_fil
 
 function s:diffview_open(...)
     lua require'diffview'.open(vim.fn.eval("a:000"))
+endfunction
+
+function s:completion(argLead, cmdLine, curPos)
+    return luaeval("require'diffview'.completion(vim.fn.eval('a:argLead'), vim.fn.eval('a:cmdLine'), vim.fn.eval('a:curPos'))")
 endfunction
 
 augroup Diffview

--- a/plugin/diffview.vim
+++ b/plugin/diffview.vim
@@ -6,10 +6,6 @@ command! -nargs=0 DiffviewFocusFiles lua require'diffview'.on_keypress("focus_fi
 command! -nargs=0 DiffviewToggleFiles lua require'diffview'.on_keypress("toggle_files")
 command! -nargs=0 DiffviewRefresh lua require'diffview'.on_keypress("refresh_files")
 
-function s:diffview_open(...)
-    lua require'diffview'.open(vim.fn.eval("a:000"))
-endfunction
-
 function s:completion(argLead, cmdLine, curPos)
     return luaeval("require'diffview'.completion("
                 \ . "vim.fn.eval('a:argLead'),"


### PR DESCRIPTION
The completion now works as follows:

- For arg 1, it completes commit SHA's and commit ranges.
- For 2 >= arg >= path separator, it completes flags, and flag values if the arg lead is the full name of a flag.
- For arg > path separator (`--`), it completes paths.

https://user-images.githubusercontent.com/2786478/117345695-1d57d900-aea7-11eb-8fd2-dadb6589a26f.mp4

