### PR TITLE
feat: Merge user bindings with defaults by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require'diffview'.setup {
     use_icons = true        -- Requires nvim-web-devicons
   },
   key_bindings = {
+    disable_defaults = false,                   -- Disable the default key bindings
     -- The `view` bindings are active in the diff buffers, only when the current
     -- tabpage is a Diffview.
     view = {

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -43,6 +43,7 @@ Example configuration with default settings:
         use_icons = true
       },
       key_bindings = {
+        disable_defaults = false,                   -- Disable the default key bindings
         -- The `view` bindings are active in the diff buffers, only when the current
         -- tabpage is a Diffview.
         view = {
@@ -153,6 +154,10 @@ o                       Open the diff for the selected file entry.
 <2-LeftMouse>
 
 -                       Stage/unstage the selected file entry.
+
+S                       Stage all entries.
+
+U                       Unstage all entries.
 
 R                       Update the stats and entries in the file list.
 

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -12,6 +12,7 @@ M.defaults = {
     use_icons = true
   },
   key_bindings = {
+    disable_defaults = false,
     view = {
       ["<tab>"]     = M.diffview_callback("select_next_entry"),
       ["<s-tab>"]   = M.diffview_callback("select_prev_entry"),
@@ -44,33 +45,16 @@ function M.get_config()
   return M._config
 end
 
-function M.tbl_soft_extend(a, b)
-  for k, v in pairs(a) do
-    if type(v) ~= "table" then
-      if b[k] ~= nil then
-        a[k] = b[k]
-      end
-    end
-  end
-end
-
 function M.setup(user_config)
   user_config = user_config or {}
   M._config = utils.tbl_deep_clone(M.defaults)
-  M.tbl_soft_extend(M._config, user_config)
+  M._config = vim.tbl_deep_extend("force", M._config, user_config)
 
-  M._config.file_panel = vim.tbl_deep_extend(
-    "force", M.defaults.file_panel, user_config.file_panel or {}
-  )
-
-  -- If the user provides key bindings: use only the user bindings.
-  if user_config.key_bindings then
-    M._config.key_bindings.view = (
-      user_config.key_bindings.view or M._config.key_bindings.view
-    )
-    M._config.key_bindings.file_panel = (
-      user_config.key_bindings.file_panel or M._config.key_bindings.file_panel
-    )
+  if M._config.key_bindings.disable_defaults then
+    M._config.key_bindings.view =
+      (user_config.key_bindings and user_config.key_bindings.view) or {}
+    M._config.key_bindings.file_panel =
+      (user_config.key_bindings and user_config.key_bindings.file_panel) or {}
   end
 end
 


### PR DESCRIPTION
Fixes #19.

This is a breaking change. The default behavior is now to merge the user
provided key bindings with the defaults. All default key bindings can be
disabled by setting `key_bindings.disable_defaults = true`.