### PR TITLE
feat: Determine git root from current buffer when possible.

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -85,7 +85,10 @@ COMMANDS                                            *diffview-nvim-commands*
                         Opens a new Diffview that compares against [git-rev].
                         If no [git-rev] is given, defaults to comparing
                         against the index. Additional {paths...} can be
-                        provided to narrow down what files are shown.
+                        provided to narrow down what files are shown. If the
+                        `-C` flag is not defined, the git root is determined
+                        from the current buffer when possible. Otherwise it's
+                        determined from the cwd.
                         Examples:
 >
         :DiffviewOpen

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -26,7 +26,13 @@ function M.parse_revs(args)
   local right
 
   local cpath = argo:get_flag("C")
-  local p = not vim.tbl_contains({"true", "", nil}, cpath) and cpath or "."
+  local fpath = (
+    vim.bo.buftype == ""
+    and vim.fn.filereadable(vim.fn.expand("%f"))
+    and vim.fn.expand("%f:p:h")
+    or "."
+  )
+  local p = not vim.tbl_contains({"true", "", nil}, cpath) and cpath or fpath
   if vim.fn.isdirectory(p) ~= 1 then
     p = vim.fn.fnamemodify(p, ":h")
   end


### PR DESCRIPTION
Fixes #33.

Currently the git root is always determined from the cwd unless the `-C` flag is defined. This changes the default behavior to try to determine the git root from the path of the current buffer when possible.

Only applies if the `-C` flag is not defined. If the current buffer is
not a readable file, the git root is determined from the cwd.