### PR TITLE
Use <Cmd> instead of :

### DIFF
--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -2,7 +2,7 @@ local utils = require'diffview.utils'
 local M = {}
 
 function M.diffview_callback(cb_name)
-  return string.format(":lua require'diffview'.on_keypress('%s')<CR>", cb_name)
+  return string.format("<Cmd>lua require'diffview'.on_keypress('%s')<CR>", cb_name)
 end
 
 M.defaults = {

--- a/lua/diffview/file-panel.lua
+++ b/lua/diffview/file-panel.lua
@@ -106,7 +106,7 @@ function FilePanel:open()
   end
 
   vim.cmd("buffer " .. self.bufid)
-  vim.cmd(":wincmd =")
+  vim.cmd("wincmd =")
 end
 
 function FilePanel:close()


### PR DESCRIPTION
When executing commands in scripts or hotkeys, it is always better to use `<Cmd>` instead of `:`. This is because the colon raises cmdline opening events. For example, in my UI it causes weird animation.
Also `<Cmd>` is faster :)

Also I removed an extra `:` from `vim.cmd`.