### PR TITLE
feat: Support symmetric difference notation.

### DIFF
--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -10,6 +10,7 @@ local M = {}
 local flag_value_completion = arg_parser.FlagValueMap:new()
 flag_value_completion:put({"u", "untracked-files"}, {"true", "normal", "all", "false", "no"})
 flag_value_completion:put({"cached", "staged"}, {"true", "false"})
+flag_value_completion:put({"C"}, {})
 
 function M.setup(user_config)
   config.setup(user_config or {})

--- a/lua/diffview/api/c-view.lua
+++ b/lua/diffview/api/c-view.lua
@@ -28,6 +28,7 @@ local M = {}
 ---@field tabpage integer
 ---@field git_root string Absolute path the root of the git directory.
 ---@field git_dir string Absolute path to the '.git' directory.
+---@field rev_arg string
 ---@field path_args string[]
 ---@field left Rev
 ---@field right Rev
@@ -51,6 +52,7 @@ function CView:new(opt)
   local this = {
     git_root = opt.git_root,
     git_dir = git.git_dir(opt.git_root),
+    rev_arg = opt.rev_arg,
     path_args = opt.path_args,
     left = opt.left,
     right = opt.right,
@@ -69,7 +71,7 @@ function CView:new(opt)
     this.git_root,
     this.files,
     this.path_args,
-    git.rev_to_pretty_string(this.left, this.right)
+    this.rev_arg or git.rev_to_pretty_string(this.left, this.right)
   )
 
   setmetatable(this, self)

--- a/lua/diffview/file-panel.lua
+++ b/lua/diffview/file-panel.lua
@@ -328,7 +328,7 @@ function FilePanel:render()
 
   if self.rev_pretty_name or (self.path_args and #self.path_args > 0) then
     local extra_info = utils.tbl_concat(
-      { self.rev_pretty_name and ("commit " .. self.rev_pretty_name) or nil },
+      { self.rev_pretty_name },
       self.path_args or {}
     )
 

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -55,8 +55,13 @@ function M.parse_revs(args)
       left = Rev:new(RevType.INDEX)
       right = Rev:new(RevType.LOCAL)
     end
+  elseif rev_arg:match("%.%.%.") then
+    left, right = git.symmetric_diff_revs(git_root, rev_arg)
+    if not (left or right) then return end
   else
-    local rev_strings = vim.fn.systemlist(base_cmd .. "rev-parse --revs-only " .. vim.fn.shellescape(rev_arg))
+    local rev_strings = vim.fn.systemlist(
+      base_cmd .. "rev-parse --revs-only " .. vim.fn.shellescape(rev_arg)
+    )
     if utils.shell_error() then
       utils.err("Failed to parse rev '" .. rev_arg .. "'!")
       utils.err("Git output: " .. vim.fn.join(rev_strings, "\n"))
@@ -94,6 +99,7 @@ function M.parse_revs(args)
 
   local v = View:new({
       git_root = git_root,
+      rev_arg = rev_arg,
       path_args = paths,
       left = left,
       right = right,

--- a/lua/diffview/view.lua
+++ b/lua/diffview/view.lua
@@ -35,6 +35,7 @@ local LayoutMode = oop.enum {
 ---@field tabpage integer
 ---@field git_root string Absolute path the root of the git directory.
 ---@field git_dir string Absolute path to the '.git' directory.
+---@field rev_arg string
 ---@field path_args string[]
 ---@field left Rev
 ---@field right Rev
@@ -56,6 +57,7 @@ function View:new(opt)
   local this = {
     git_root = opt.git_root,
     git_dir = git.git_dir(opt.git_root),
+    rev_arg = opt.rev_arg,
     path_args = opt.path_args,
     left = opt.left,
     right = opt.right,
@@ -71,7 +73,7 @@ function View:new(opt)
     this.git_root,
     this.files,
     this.path_args,
-    git.rev_to_pretty_string(this.left, this.right)
+    this.rev_arg or git.rev_to_pretty_string(this.left, this.right)
   )
   FileEntry.update_index_stat(this.git_root, this.git_dir)
   setmetatable(this, self)


### PR DESCRIPTION
Fixes #47.

Rev args can now use the symmetric difference notation (triple dot).
Examples:
- `:DiffviewOpen origin/main...HEAD`
- `:DiffviewOpen feat/foobar...`

Also changes the "Showing changes for:" section of the file panel. It will now show the given rev arg rather than the parsed commit SHA's.