### PR TITLE
feat: Restore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ require'diffview'.setup {
       ["-"]             = cb("toggle_stage_entry"), -- Stage / unstage the selected entry.
       ["S"]             = cb("stage_all"),          -- Stage all entries.
       ["U"]             = cb("unstage_all"),        -- Unstage all entries.
+      ["X"]             = cb("restore_entry"),      -- Restore entry to the state on the left side.
       ["R"]             = cb("refresh_files"),      -- Update stats and entries in the file list.
       ["<tab>"]         = cb("select_next_entry"),
       ["<s-tab>"]       = cb("select_prev_entry"),
@@ -75,8 +76,9 @@ require'diffview'.setup {
 }
 ```
 
-The diff windows can be aligned either horizontally or vertically. To change
-the alignment add either `horizontal` or `vertical` to your `'diffopt'`.
+The diff windows can be aligned either with a horizontal split or a vertical
+split. To change the alignment add either `horizontal` or `vertical` to your
+`'diffopt'`.
 
 ## Usage
 
@@ -120,3 +122,10 @@ files with `<tab>` and `<s-tab>` (see configuration to change the key bindings).
 - **Diff the index against a git rev:**
   - `DiffviewOpen HEAD~2 --cached`
   - Defaults to `HEAD` if no rev is given.
+
+## Restoring Files
+
+If the right side of the diff is showing the local state of a file, you can
+restore the file to the state from the left side of the diff (key binding `X`
+from the file panel by default). The current state of the file is stored in the
+git object database, and a command is echoed that shows how to undo the change.

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -63,6 +63,7 @@ Example configuration with default settings:
           ["-"]             = cb("toggle_stage_entry"), -- Stage / unstage the selected entry.
           ["S"]             = cb("stage_all"),          -- Stage all entries.
           ["U"]             = cb("unstage_all"),        -- Unstage all entries.
+          ["X"]             = cb("restore_entry"),      -- Restore entry to the state on the left side.
           ["R"]             = cb("refresh_files"),      -- Update stats and entries in the file list.
           ["<tab>"]         = cb("select_next_entry"),
           ["<s-tab>"]       = cb("select_prev_entry"),
@@ -75,8 +76,9 @@ Example configuration with default settings:
 
 LAYOUT                                                *diffview-nvim-layout*
 
-The diff windows can be aligned either horizontally or vertically. To change
-the alignment add either `horizontal` or `vertical` to your *'diffopt'* .
+The diff windows can be aligned either with a horizontal split or a vertical
+split. To change the alignment add either `horizontal` or `vertical` to your
+*'diffopt'* .
 
 COMMANDS                                            *diffview-nvim-commands*
 
@@ -164,6 +166,12 @@ o                       Open the diff for the selected file entry.
 S                       Stage all entries.
 
 U                       Unstage all entries.
+
+X                       Revert the selected file entry to the state from the
+                        left side of the diff. This only works if the right
+                        side of the diff is showing the local state of the
+                        file. A command is echoed that shows how to undo the
+                        change. Check `:messages` to see it again.
 
 R                       Update the stats and entries in the file list.
 

--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -183,6 +183,24 @@ M.keypress_event_cbs = {
       view.emitter:emit(Event.FILES_STAGED, { view })
     end
   end,
+  restore_entry = function ()
+    local view = lib.get_current_diffview()
+    if view then
+      local commit
+      if not (view.right.type == RevType.LOCAL) then
+        utils.err("Neither side of the diff are local! Aborting file restoration.")
+        return
+      end
+      if not (view.left.type == RevType.INDEX) then
+        commit = view.left.commit
+      end
+      local file = view.file_panel:get_file_at_cursor()
+      if file then
+        require'diffview.git'.restore_file(view.git_root, file.path, file.kind, commit)
+        view:update_files()
+      end
+    end
+  end,
   focus_files = function ()
     local view = lib.get_current_diffview()
     if view then

--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -188,7 +188,7 @@ M.keypress_event_cbs = {
     if view then
       local commit
       if not (view.right.type == RevType.LOCAL) then
-        utils.err("Neither side of the diff are local! Aborting file restoration.")
+        utils.err("The right side of the diff is not local! Aborting file restoration.")
         return
       end
       if not (view.left.type == RevType.INDEX) then
@@ -196,6 +196,11 @@ M.keypress_event_cbs = {
       end
       local file = view.file_panel:get_file_at_cursor()
       if file then
+        local bufid = utils.find_file_buffer(file.path)
+        if bufid and vim.bo[bufid].modified then
+          utils.err("The file is open with unsaved changes! Aborting file restoration.")
+          return
+        end
         require'diffview.git'.restore_file(view.git_root, file.path, file.kind, commit)
         view:update_files()
       end

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -30,6 +30,7 @@ M.defaults = {
       ["-"]             = M.diffview_callback("toggle_stage_entry"),
       ["S"]             = M.diffview_callback("stage_all"),
       ["U"]             = M.diffview_callback("unstage_all"),
+      ["X"]             = M.diffview_callback("restore_entry"),
       ["R"]             = M.diffview_callback("refresh_files"),
       ["<tab>"]         = M.diffview_callback("select_next_entry"),
       ["<s-tab>"]       = M.diffview_callback("select_prev_entry"),

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -284,6 +284,15 @@ function M.wipe_named_buffer(name)
   end
 end
 
+function M.find_file_buffer(path)
+  local p = vim.fn.fnamemodify(path, ":p")
+  for _, id in ipairs(vim.api.nvim_list_bufs()) do
+    if p == vim.api.nvim_buf_get_name(id) then
+      return id
+    end
+  end
+end
+
 ---Get a list of all windows that contain the given buffer.
 ---@param bufid integer
 ---@return integer[]


### PR DESCRIPTION
Fixes #43.

This implements file restoration: if the right side of the diff is showing the local state of the file, you can restore the file to the state from the left side of the diff (key binding `X` from the file panel by default). Staged changes are restored from `HEAD`.