### PR TITLE
feat: Implement enhanced diff highlighting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ local cb = require'diffview.config'.diffview_callback
 require'diffview'.setup {
   diff_binaries = false,    -- Show diffs for binaries
   use_icons = true,         -- Requires nvim-web-devicons
+  enhanced_diff_hl = false, -- See ':h diffview-config-enhanced_diff_hl'
   signs = {
     fold_closed = "",
     fold_open = "",

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -7,14 +7,14 @@ Author: Sindre T. Strøm
 
 ==============================================================================
 
-INTRODUCTION                                       *diffview-nvim-introduction*
+INTRODUCTION                                            *diffview-introduction*
 
 Vim's diff mode is pretty good, but there is no convenient way to quickly bring
 up all modified files in a diffsplit. This plugin aims to provide a simple,
 unified, single tabpage interface that lets you easily review all changed files
 for any git rev.
 
-USAGE                                                   *diffview-nvim-usage*
+USAGE                                                        *diffview-usage*
 
 Quick-start: `:DiffviewOpen` to open a Diffview that compares against the
 index.
@@ -30,7 +30,7 @@ Diffviews are automatically updated:
 
 Updates are not run unless the current tabpage is a Diffview.
 
-CONFIGURATION                                   *diffview-nvim-configuration*
+CONFIGURATION                                                *diffview-config*
 
 Example configuration with default settings:
 >
@@ -38,7 +38,8 @@ Example configuration with default settings:
     local cb = require'diffview.config'.diffview_callback
     require'diffview'.setup {
       diff_binaries = false,    -- Show diffs for binaries
-      use_icons = true          -- Requires nvim-web-devicons
+      use_icons = true,         -- Requires nvim-web-devicons
+      enhanced_diff_hl = false, -- See |diffview-config-enhanced_diff_hl|
       signs = {
         fold_closed = "",
         fold_open = "",
@@ -123,13 +124,20 @@ Example configuration with default settings:
     }
 <
 
-LAYOUT                                                *diffview-nvim-layout*
+enhanced_diff_hl                            *diffview-config-enhanced_diff_hl*
+        Type: `boolean`, Default: `false`
+
+        Enable/disable enhanced diff highlighting. When enabled, |hl-DiffAdd|
+        in the left diff buffer will be highlighted as |hl-DiffDelete|, and
+        the delete fill-chars will be highlighted more subtly.
+
+LAYOUT                                                     *diffview-layout*
 
 The diff windows can be aligned either with a horizontal split or a vertical
 split. To change the alignment add either `horizontal` or `vertical` to your
 'diffopt'.
 
-COMMANDS                                            *diffview-nvim-commands*
+COMMANDS                                                 *diffview-commands*
 
                                                         *:DiffviewOpen*
 :DiffviewOpen [git-rev] [args] [ -- {paths...}]
@@ -194,7 +202,7 @@ COMMANDS                                            *diffview-nvim-commands*
 :DiffviewRefresh        Update stats and entries in the file list of the
                         current Diffview.
 
-MAPS                                                      *diffview-nvim-maps*
+MAPS                                                           *diffview-maps*
 
 All listed maps are the defaults, but all mappings can be configured. Most of
 the file panel mappings should also work from the view if they are added to
@@ -205,7 +213,7 @@ really make sense specifically in the file panel, such as `next_entry`,
 these will target the file currently open in the view rather than the file
 under the cursor in the file panel.
 
-                                                 *diffview-nvim-file-inference*
+                                                      *diffview-file-inference*
 File inference~
 
 Mappings that target a file will infer the target file according to a set of
@@ -216,19 +224,19 @@ simple rules:
         - If the cursor is in a file panel, the target file will be determined by
           the entry under the cursor.
 
-                                                      *diffview-nvim-maps-view*
+                                                           *diffview-maps-view*
 View maps~
 
 These maps are available in the diff buffers while a Diffview is the current
 tabpage.
 
-                                         *diffview-nvim-maps-select_next_entry*
+                                              *diffview-maps-select_next_entry*
 <Tab>                   Open the diff for the next file.
 
-                                         *diffview-nvim-maps-select_prev_entry*
+                                              *diffview-maps-select_prev_entry*
 <S-Tab>                 Open the diff for the previous file.
 
-                                                *diffview-nvim-maps-goto_file*
+                                                     *diffview-maps-goto_file*
 gf                      Open the local version of the file in a new split in a
                         different tabpage. This will target your previous
                         (last accessed) tabpage first. If you have no
@@ -236,57 +244,57 @@ gf                      Open the local version of the file in a new split in a
                         new tabpage. See |diffview-nvim-file-inference| for
                         details on how the file target is determined.
 
-                                          *diffview-nvim-maps-goto_file_split*
+                                               *diffview-maps-goto_file_split*
 <C-w><C-f>              Open the local version of the file in a new split. See
                         |diffview-nvim-file-inference| for details on how the
                         file target is determined.
 
-                                            *diffview-nvim-maps-goto_file_tab*
+                                                 *diffview-maps-goto_file_tab*
 <C-w>gf                 Open the local version of the file in a new tabpage.
                         See |diffview-nvim-file-inference| for details on how
                         the file target is determined.
 
-                                              *diffview-nvim-maps-toggle_files*
+                                                   *diffview-maps-toggle_files*
 <leader>b               Toggle the file panel.
 
-                                               *diffview-nvim-maps-focus_files*
+                                                    *diffview-maps-focus_files*
 <leader>e               Bring focus to the file panel.
 
-                                               *diffview-nvim-maps-file-panel*
+                                                    *diffview-maps-file-panel*
 File panel maps~
 
 These maps are available in the file panel buffer.
 
-                                                *diffview-nvim-maps-next_entry*
+                                                     *diffview-maps-next_entry*
 j                       Bring the cursor to the next file entry
 <Down>
 
-                                                *diffview-nvim-maps-prev_entry*
+                                                     *diffview-maps-prev_entry*
 k                       Bring the cursor to the previous file entry
 <Up>
 
-                                              *diffview-nvim-maps-select_entry*
+                                                   *diffview-maps-select_entry*
 o                       Open the diff for the selected file entry.
 <CR>
 <2-LeftMouse>
 
-                                        *diffview-nvim-maps-toggle_stage_entry*
+                                             *diffview-maps-toggle_stage_entry*
 -                       Stage/unstage the selected file entry.
 
-                                                 *diffview-nvim-maps-stage_all*
+                                                      *diffview-maps-stage_all*
 S                       Stage all entries.
 
-                                               *diffview-nvim-maps-unstage_all*
+                                                    *diffview-maps-unstage_all*
 U                       Unstage all entries.
 
-                                             *diffview-nvim-maps-restore_entry*
+                                                  *diffview-maps-restore_entry*
 X                       Revert the selected file entry to the state from the
                         left side of the diff. This only works if the right
                         side of the diff is showing the local state of the
                         file. A command is echoed that shows how to undo the
                         change. Check `:messages` to see it again.
 
-                                             *diffview-nvim-maps-refresh_files*
+                                                  *diffview-maps-refresh_files*
 R                       Update the stats and entries in the file list.
 
 <Tab>                   Open the diff for the next file.
@@ -299,23 +307,23 @@ R                       Update the stats and entries in the file list.
 
 <leader>e               Bring focus to the file panel.
 
-                                        *diffview-nvim-maps-file-history-panel*
+                                             *diffview-maps-file-history-panel*
 File history panel maps~
 
 These mappings are available in the file history panel buffer (the panel
 listing the commits).
 
-                                                   *diffview-nvim-maps-options*
+                                                        *diffview-maps-options*
 g!                      Open the options panel.
 
-                                          *diffview-nvim-maps-open_in_diffview*
+                                               *diffview-maps-open_in_diffview*
 <C-d>                   Open the commit entry under the cursor in a Diffview.
 
-                                            *diffview-nvim-maps-open_all_folds*
+                                                 *diffview-maps-open_all_folds*
 zR                      Open the fold on all commit entries (only when showing
                         history for multiple files).
 
-                                           *diffview-nvim-maps-close_all_folds*
+                                                *diffview-maps-close_all_folds*
 zM                      Close the fold on all commit entries (only when showing
                         history for multiple files).
 
@@ -339,7 +347,7 @@ o                       Open the diff for the selected item.
 
 <leader>e               Bring focus to the file history panel.
 
-                                 *diffview-nvim-maps-file-history-option-panel*
+                                      *diffview-maps-file-history-option-panel*
 File history option panel maps~
 
 These mappings are available from the file history options panel. The option

--- a/lua/diffview/api/views/diff/diff_view.lua
+++ b/lua/diffview/api/views/diff/diff_view.lua
@@ -34,6 +34,7 @@ function CDiffView:init(opt)
   self.layout_mode = CDiffView.get_layout_mode()
   self.nulled = false
   self.ready = false
+  self.winopts = { left = {}, right = {} }
   self.git_root = opt.git_root
   self.git_dir = git.git_dir(opt.git_root)
   self.rev_arg = opt.rev_arg

--- a/lua/diffview/colors.lua
+++ b/lua/diffview/colors.lua
@@ -79,7 +79,17 @@ M.hl_links = {
   StatusIgnored = "Comment",
 }
 
+function M.update_diff_hl()
+  local fg = M.get_fg("DiffDelete") or "NONE"
+  local bg = M.get_bg("DiffDelete") or "red"
+  local gui = M.get_gui("DiffDelete") or "NONE"
+  vim.cmd(string.format("hi def DiffviewDiffAddAsDelete guifg=%s guibg=%s gui=%s", fg, bg, gui))
+  vim.cmd("hi def link DiffviewDiffDelete Comment")
+end
+
 function M.setup()
+  M.update_diff_hl()
+
   for name, v in pairs(M.get_hl_groups()) do
     local fg = v.fg and " guifg=" .. v.fg or ""
     local bg = v.bg and " guibg=" .. v.bg or ""

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -11,6 +11,7 @@ local cb = M.diffview_callback
 M.defaults = {
   diff_binaries = false,
   use_icons = true,
+  enhanced_diff_hl = false,
   signs = {
     fold_closed = "",
     fold_open = "",

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -413,6 +413,12 @@ function M.tbl_indexof(t, v)
   return -1
 end
 
+function M.tbl_clear(t)
+  for k, _ in pairs(t) do
+    t[k] = nil
+  end
+end
+
 function M.find_named_buffer(name)
   for _, v in ipairs(api.nvim_list_bufs()) do
     if vim.fn.bufname(v) == name then

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -38,6 +38,7 @@ function DiffView:init(opt)
   self.layout_mode = DiffView.get_layout_mode()
   self.ready = false
   self.nulled = false
+  self.winopts = { left = {}, right = {} }
   self.git_root = opt.git_root
   self.git_dir = git.git_dir(opt.git_root)
   self.rev_arg = opt.rev_arg
@@ -101,6 +102,7 @@ function DiffView:next_file()
     vim.cmd("diffoff!")
     cur = self.files[self.file_idx]
     cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
+    self:update_windows()
     self.panel:highlight_file(self:cur_file())
     self.nulled = false
 
@@ -123,6 +125,7 @@ function DiffView:prev_file()
     vim.cmd("diffoff!")
     cur = self.files[self.file_idx]
     cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
+    self:update_windows()
     self.panel:highlight_file(self:cur_file())
     self.nulled = false
 
@@ -145,6 +148,7 @@ function DiffView:set_file(file, focus)
       self.file_idx = i
       vim.cmd("diffoff!")
       self.files[self.file_idx]:load_buffers(self.git_root, self.left_winid, self.right_winid)
+      self:update_windows()
       self.panel:highlight_file(self:cur_file())
       self.nulled = false
 
@@ -281,12 +285,14 @@ function DiffView:recover_layout(state)
     vim.cmd("aboveleft " .. split_cmd)
     self.left_winid = api.nvim_get_current_win()
     self.panel:open()
+    self:post_layout()
     self:set_file(self:cur_file())
   elseif not state.right_win then
     api.nvim_set_current_win(self.left_winid)
     vim.cmd("belowright " .. split_cmd)
     self.right_winid = api.nvim_get_current_win()
     self.panel:open()
+    self:post_layout()
     self:set_file(self:cur_file())
   end
 

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -70,6 +70,7 @@ function FileHistoryView:next_item()
     cur = self.panel:next_file()
     if cur then
       cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
+      self:update_windows()
       self.panel:highlight_item(cur)
       self.nulled = false
 
@@ -93,6 +94,7 @@ function FileHistoryView:prev_item()
     cur = self.panel:prev_file()
     if cur then
       cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
+      self:update_windows()
       self.panel:highlight_item(cur)
       self.nulled = false
 
@@ -115,6 +117,7 @@ function FileHistoryView:set_file(file, focus)
     end
     vim.cmd("diffoff!")
     file:load_buffers(self.git_root, self.left_winid, self.right_winid)
+    self:update_windows()
     self.panel.cur_item = { entry, file }
     self.panel:highlight_item(file)
     self.nulled = false

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -25,6 +25,7 @@ function FileHistoryView:init(opt)
   self.layout_mode = FileHistoryView.get_layout_mode()
   self.ready = false
   self.nulled = false
+  self.winopts = { left = {}, right = {} }
   self.git_root = opt.git_root
   self.git_dir = git.git_dir(self.git_root)
   self.path_args = opt.path_args
@@ -150,12 +151,14 @@ function FileHistoryView:recover_layout(state)
     vim.cmd("aboveleft " .. split_cmd)
     self.left_winid = api.nvim_get_current_win()
     self.panel:open()
+    self:post_layout()
     self:set_file(self.panel.cur_item[2])
   elseif not state.right_win then
     api.nvim_set_current_win(self.left_winid)
     vim.cmd("belowright " .. split_cmd)
     self.right_winid = api.nvim_get_current_win()
     self.panel:open()
+    self:post_layout()
     self:set_file(self.panel.cur_item[2])
   end
 


### PR DESCRIPTION
Resolves #52.

As pointed out by @YorickPeterse, the way vim highlights diffs isn't the most intuitive when you're comparing only two files (vim has to do it this way of course, because it's the only way that makes sense when you're comparing *more* than two files).  When comparing old state on the left with new state on the right, what vim highlights as an addition on the left, actually represents a deletion.

This PR adds a new option `enhanced_diff_hl` that attempts to tackle this issue. When enabled, a couple new highlighting groups will be generated based on your colorscheme. These will be applied as local `winhl` in the diff buffers.

```vimhelp
enhanced_diff_hl                            *diffview-config-enhanced_diff_hl*
        Type: `boolean`, Default: `false`

        Enable/disable enhanced diff highlighting. When enabled, |hl-DiffAdd|
        in the left diff buffer will be highlighted as |hl-DiffDelete|, and
        the delete fill-chars will be highlighted more subtly.
```

Before:

![2021-09-06-151601_maim](https://user-images.githubusercontent.com/2786478/132223449-fdd7d8ec-8ed4-4fe8-a0a8-559d878600f8.png)

After:

![2021-09-06-151538_maim](https://user-images.githubusercontent.com/2786478/132223469-1d3d7346-2082-4e1d-9531-ac5860bc1b8d.png)