### PR TITLE
Do not change cursor position on select_entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for any git rev.
 Install the plugin with your package manager of choice.
 
 ```vim
-" Plug 
+" Plug
 Plug 'sindrets/diffview.nvim'
 ```
 
@@ -70,7 +70,7 @@ require'diffview'.setup {
     -- The `view` bindings are active in the diff buffers, only when the current
     -- tabpage is a Diffview.
     view = {
-      ["<tab>"]      = cb("select_next_entry"),  -- Open the diff for the next file 
+      ["<tab>"]      = cb("select_next_entry"),  -- Open the diff for the next file
       ["<s-tab>"]    = cb("select_prev_entry"),  -- Open the diff for the previous file
       ["gf"]         = cb("goto_file"),          -- Open the file in a new split in previous tabpage
       ["<C-w><C-f>"] = cb("goto_file_split"),    -- Open the file in a new split
@@ -138,6 +138,15 @@ that only really make sense specifically in the file panel, such as
 `toggle_stage_entry` and `restore_entry` work just fine from the view. When
 invoked from the view, these will target the file currently open in the view
 rather than the file under the cursor in the file panel.
+
+### Available Unused Mappings
+
+This section documents key-mappable functions that are not mapped by default.
+
+- `focus_entry`
+  - Like `select_entry`, but open the diff for the selected entry while
+    focusing cursor on the current file. Available in both the file panel and
+    the history panel.
 
 ## File History
 

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -67,7 +67,7 @@ Example configuration with default settings:
         -- The `view` bindings are active in the diff buffers, only when the current
         -- tabpage is a Diffview.
         view = {
-          ["<tab>"]      = cb("select_next_entry"),  -- Open the diff for the next file 
+          ["<tab>"]      = cb("select_next_entry"),  -- Open the diff for the next file
           ["<s-tab>"]    = cb("select_prev_entry"),  -- Open the diff for the previous file
           ["gf"]         = cb("goto_file"),          -- Open the file in a new split in previous tabpage
           ["<C-w><C-f>"] = cb("goto_file_split"),    -- Open the file in a new split
@@ -130,6 +130,15 @@ enhanced_diff_hl                            *diffview-config-enhanced_diff_hl*
         Enable/disable enhanced diff highlighting. When enabled, |hl-DiffAdd|
         in the left diff buffer will be highlighted as |hl-DiffDelete|, and
         the delete fill-chars will be highlighted more subtly.
+
+AVAILABLE UNUSED MAPPINGS                 *diffview-available-unused-mappings*
+
+This section documents key-mappable functions that are not mapped by default.
+
+focus_entry                                     *diffview-config-focus-entry*
+        Like select_entry, but open the diff for the selected entry while
+        focusing cursor on the current file. Available in both the file panel
+        and the history panel.
 
 LAYOUT                                                     *diffview-layout*
 

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -69,6 +69,14 @@ return function(view)
         end
       end
     end,
+    focus_entry = function()
+      if view.panel:is_open() then
+        local file = view.panel:get_file_at_cursor()
+        if file then
+          view:set_file(file, true)
+        end
+      end
+    end,
     toggle_stage_entry = function()
       if not (view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL) then
         return

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -65,7 +65,7 @@ return function(view)
       if view.panel:is_open() then
         local file = view.panel:get_file_at_cursor()
         if file then
-          view:set_file(file, true)
+          view:set_file(file, false)
         end
       end
     end,

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -95,6 +95,23 @@ return function(view)
           -- print(vim.inspect(item))
           if item.files then
             if view.panel.single_file then
+              view:set_file(item.files[1], false)
+            else
+              view.panel:toggle_entry_fold(item)
+            end
+          else
+            view:set_file(item, false)
+          end
+        end
+      end
+    end,
+    focus_entry = function()
+      if view.panel:is_cur_win() then
+        local item = view.panel:get_item_at_cursor()
+        if item then
+          -- print(vim.inspect(item))
+          if item.files then
+            if view.panel.single_file then
               view:set_file(item.files[1], true)
             else
               view.panel:toggle_entry_fold(item)


### PR DESCRIPTION
Both `select_next_entry` and `select_prev_entry` do not change cursor position. To be consistent with this behavior, I think it would be best to not move the cursor when calling `select_entry`.

Alternatively, we can define a new function to preserve existing behavior. That said, I find myself visually browsing diffs more often than I need to move my cursor into the diffs, so I think this is a reasonable default.