### PR TITLE
fix: file history when .git is not on upper level

### DIFF
--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -381,6 +381,19 @@ function M.git_dir(path)
   return vim.trim(out)
 end
 
+---Get the path of the given file relative to the project .git directory.
+---@param path string
+---@return string|nil
+function M.git_relpath(path)
+  local out = vim.fn.system(
+    "git ls-tree --full-name --name-only HEAD " .. vim.fn.shellescape(path)
+  )
+  if utils.shell_error() then
+    return nil
+  end
+  return vim.trim(out)
+end
+
 ---Check if any of the given revs are LOCAL.
 ---@param left Rev
 ---@param right Rev

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -103,6 +103,11 @@ function M.file_history(args)
     return
   end
 
+  -- Use paths relative to git root
+  for i, path in ipairs(paths) do
+    paths[i] = git.git_relpath(path)
+  end
+
   ---@type FileHistoryView
   local v = FileHistoryView({
     git_root = git_root,


### PR DESCRIPTION
Resolves #76 

Fixes the issue of `DiffviewFileHistory` not working when the project root is not on the same level as the `.git` folder.

The cause of the issue was that paths being passed to the `FileHistoryView` are relative to the vim project root, but not the `.git` project root - e.g. passing `diffview.lua` instead of `lua/diffview.lua`.