### PR TITLE
perf: Improve renderer performance.

### DIFF
--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -1,3 +1,12 @@
+DiffviewGlobal = {}
+--[[
+Debug Levels:
+0:    NOTHING
+1:    NORMAL
+10:   RENDERING
+--]]
+DiffviewGlobal.debug_level = tonumber(os.getenv("DEBUG_DIFFVIEW")) or 0
+
 local arg_parser = require("diffview.arg_parser")
 local lib = require("diffview.lib")
 local config = require("diffview.config")

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -44,6 +44,8 @@ function FlagValueMap:init()
   self.map = {}
 end
 
+---@param flag_synonyms string[]
+---@param values string[]
 function FlagValueMap:put(flag_synonyms, values)
   for _, flag in ipairs(flag_synonyms) do
     if flag:sub(1, 1) ~= "-" then

--- a/lua/diffview/git/file_dict.lua
+++ b/lua/diffview/git/file_dict.lua
@@ -16,18 +16,19 @@ FileDict = oop.create_class("FileDict")
 function FileDict:init()
   self.working = {}
   self.staged = {}
+end
 
-  local mt = getmetatable(self)
-  local old_index = mt.__index
-  mt.__index = function(t, k)
+do
+  local __index = FileDict.__index
+  function FileDict.__index(self, k)
     if type(k) == "number" then
-      if k > #t.working then
-        return t.staged[k - #t.working]
+      if k > #self.working then
+        return self.staged[k - #self.working]
       else
-        return t.working[k]
+        return self.working[k]
       end
     else
-      return old_index(t, k)
+      return __index(self, k)
     end
   end
 end
@@ -37,7 +38,7 @@ function FileDict:update_file_trees()
   self.staged_tree = FileTree(self.staged)
 end
 
-function FileDict:size()
+function FileDict:len()
   return #self.working + #self.staged
 end
 

--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -394,6 +394,12 @@ function M.expand_pathspec(git_root, cwd, pathspec)
   return magic .. pattern
 end
 
+function M.pathspec_modify(pathspec, mods)
+  local magic = pathspec:match("^:[/!^]*:?") or pathspec:match("^:%b()") or ""
+  local pattern = pathspec:sub(1 + #magic, -1)
+  return magic .. vim.fn.fnamemodify(pattern, mods)
+end
+
 ---Check if any of the given revs are LOCAL.
 ---@param left Rev
 ---@param right Rev

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -112,6 +112,7 @@ function M.file_history(args)
   local v = FileHistoryView({
     git_root = git_root,
     path_args = paths,
+    raw_args = argo.args,
     log_options = config.get_config().file_history_panel.log_options,
   })
 

--- a/lua/diffview/logger.lua
+++ b/lua/diffview/logger.lua
@@ -1,0 +1,37 @@
+local utils = require("diffview.utils")
+local Mock = require("diffview.mock").Mock
+
+-- If plenary is not installed: mock the logger object
+local ok, log = pcall(require, "plenary.log")
+if not ok then
+  log = Mock({
+    new = function()
+      return log
+    end,
+  })
+end
+
+local logger = log.new({
+  plugin = "diffview",
+  highlights = false,
+  use_console = false,
+  level = DiffviewGlobal.debug_level > 0 and "debug" or "error",
+})
+
+-- Add scheduled variants of the different log methods.
+for _, kind in ipairs({ "trace", "debug", "info", "warn", "error", "fatal" }) do
+  logger["s_" .. kind] = function(...)
+    local args = utils.tbl_pack(...)
+    vim.schedule(function()
+      args = vim.tbl_map(function(v)
+        if type(v) == "table" and type(v.__tostring) == "function" then
+          return tostring(v)
+        end
+        return v
+      end, args)
+      logger[kind](utils.tbl_unpack(args))
+    end)
+  end
+end
+
+return logger

--- a/lua/diffview/mock.lua
+++ b/lua/diffview/mock.lua
@@ -1,0 +1,33 @@
+--[[
+A class for creating mock objects. Accessing any key in the object returns
+itself. Calling the object does nothing.
+--]]
+
+local utils = require("diffview.utils")
+local M = {}
+local mock_mt = {}
+local Mock = setmetatable({}, mock_mt)
+
+function mock_mt.__index(_, key)
+  return mock_mt[key]
+end
+
+function mock_mt.__call(internals)
+  local mt = {
+    __index = function(self, k)
+      if Mock[k] then
+        return Mock[k]
+      else
+        return self
+      end
+    end,
+    __call = function()
+      return
+    end,
+  }
+  local this = setmetatable(utils.tbl_slice(internals or {}), mt)
+  return this
+end
+
+M.Mock = Mock
+return M

--- a/lua/diffview/oop.lua
+++ b/lua/diffview/oop.lua
@@ -98,9 +98,6 @@ local function secure_cast(class, inst)
   return casted
 end
 
-local callup_store = {}
-setmetatable(callup_store, { __mode = "k" })
-
 local function inst_init_def(inst)
   inst.super:init()
 end

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -1,9 +1,14 @@
 local oop = require("diffview.oop")
 local utils = require("diffview.utils")
 local renderer = require("diffview.renderer")
+local logger = require("diffview.logger")
+local PerfTimer = require("diffview.perf").PerfTimer
 local api = vim.api
 local M = {}
 local uid_counter = 0
+
+---@type PerfTimer
+local perf = PerfTimer("[Panel] redraw")
 
 ---@class Form
 
@@ -222,7 +227,12 @@ function Panel:redraw()
   if not self.render_data then
     return
   end
+  perf:reset()
   renderer.render(self.bufid, self.render_data)
+  perf:time()
+  if DiffviewGlobal.debug_level >= 10 then
+    logger.s_debug(perf)
+  end
 end
 
 M.Form = Form

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -83,7 +83,7 @@ function DiffView:next_file()
     return
   end
 
-  if self.files:size() > 1 or self.nulled then
+  if self.files:len() > 1 or self.nulled then
     local cur = self.panel.cur_file
     if cur then
       cur:detach_buffers()
@@ -107,7 +107,7 @@ function DiffView:prev_file()
     return
   end
 
-  if self.files:size() > 1 or self.nulled then
+  if self.files:len() > 1 or self.nulled then
     local cur = self.panel.cur_file
     if cur then
       cur:detach_buffers()
@@ -294,7 +294,7 @@ end
 ---Ensures there are files to load, and loads the null buffer otherwise.
 ---@return boolean
 function DiffView:file_safeguard()
-  if self.files:size() == 0 then
+  if self.files:len() == 0 then
     local cur = self.panel.cur_file
     if cur then
       cur:detach_buffers()

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -165,7 +165,7 @@ end
 
 function FilePanel:prev_file()
   local files = self:ordered_file_list()
-  if not self.cur_file and self.files:size() > 0 then
+  if not self.cur_file and self.files:len() > 0 then
     self.cur_file = files[1]
     return self.cur_file
   end
@@ -179,7 +179,7 @@ end
 
 function FilePanel:next_file()
   local files = self:ordered_file_list()
-  if not self.cur_file and self.files:size() > 0 then
+  if not self.cur_file and self.files:len() > 0 then
     self.cur_file = files[1]
     return self.cur_file
   end
@@ -252,19 +252,26 @@ function FilePanel:highlight_file(file)
 end
 
 function FilePanel:highlight_prev_file()
-  if not (self:is_open() and self:buf_loaded()) or self.files:size() == 0 then
+  if not (self:is_open() and self:buf_loaded()) or self.files:len() == 0 then
     return
   end
 
-  pcall(api.nvim_win_set_cursor, self.winid, { self.constrain_cursor(self.winid, -1), 0 })
+  pcall(
+    api.nvim_win_set_cursor,
+    self.winid,
+    { self.constrain_cursor(self.winid, -vim.v.count1), 0 }
+  )
 end
 
 function FilePanel:highlight_next_file()
-  if not (self:is_open() and self:buf_loaded()) or self.files:size() == 0 then
+  if not (self:is_open() and self:buf_loaded()) or self.files:len() == 0 then
     return
   end
 
-  pcall(api.nvim_win_set_cursor, self.winid, { self.constrain_cursor(self.winid, 1), 0 })
+  pcall(api.nvim_win_set_cursor, self.winid, {
+    self.constrain_cursor(self.winid, vim.v.count1),
+    0,
+  })
 end
 
 function FilePanel:set_item_fold(item, open)

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -15,6 +15,7 @@ local M = {}
 ---@field git_dir string
 ---@field panel FileHistoryPanel
 ---@field path_args string[]
+---@field raw_args string[]
 ---@field entries LogEntry[]
 ---@field file_idx integer
 local FileHistoryView = StandardView
@@ -29,9 +30,16 @@ function FileHistoryView:init(opt)
   self.git_root = opt.git_root
   self.git_dir = git.git_dir(self.git_root)
   self.path_args = opt.path_args
+  self.raw_args = opt.raw_args
   self.entries = git.file_history_list(self.git_root, self.path_args, opt.log_options)
   self.file_idx = 1
-  self.panel = FileHistoryPanel(self.git_root, self.entries, self.path_args, opt.log_options)
+  self.panel = FileHistoryPanel(
+    self.git_root,
+    self.entries,
+    self.path_args,
+    self.raw_args,
+    opt.log_options
+  )
 end
 
 function FileHistoryView:post_open()

--- a/lua/diffview/views/file_tree/node.lua
+++ b/lua/diffview/views/file_tree/node.lua
@@ -43,7 +43,7 @@ end
 ---Directory nodes come before file nodes.
 ---@param a Node
 ---@param b Node
----@return true if node a comes before node b
+---@return boolean true if node a comes before node b
 function Node.comparator(a, b)
   if a:has_children() == b:has_children() then
     return string.lower(a.name) < string.lower(b.name)


### PR DESCRIPTION
- Renderer:
  - Reduce assignments.
  - Reduce iterations.
  - Cache icons.
- Misc:
  - `next_entry` and `prev_entry` respects `v:count`.
  - Implemented some simple logging for debugging rendering. Uses
    plenary if installed.
  - Fixed args in the file history view always being displayed as
    absolute paths.