### PR TITLE
BREAKING CHANGE: Async file history

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ Install the plugin with your package manager of choice.
 
 ```vim
 " Plug
+Plug 'nvim-lua/plenary.nvim'
 Plug 'sindrets/diffview.nvim'
 ```
 
 ```lua
 -- Packer
-use 'sindrets/diffview.nvim'
+use { 'sindrets/diffview.nvim', requires = 'nvim-lua/plenary.nvim' }
 ```
 
 ## Configuration

--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -1,7 +1,24 @@
 ================================================================================
                                                           *diffview.changelog*
 
-# Changelog
+CHANGELOG
+
+                                                       *diffview.changelog-93*
+
+PR: https://github.com/sindrets/diffview.nvim/pull/93
+
+The plugin will from here on out require `plenary.nvim`:
+https://github.com/nvim-lua/plenary.nvim
+
+I'm using plenary for it's async utilities as well as job management. To
+update, just make sure plenary is loaded before diffview. Examples:
+
+        Packer:~
+            `use { 'sindrets/diffview.nvim', requires = 'nvim-lua/plenary.nvim' }`
+
+        Plug:~
+            `Plug 'nvim-lua/plenary.nvim'`
+            `Plug 'sindrets/diffview.nvim'`
 
                                                        *diffview.changelog-64*
 

--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -79,10 +79,9 @@ function M.completion(arg_lead, cmd_line, cur_pos)
   for i = 2, math.min(#args, divideridx) do
     if args[i]:sub(1, 1) ~= "-" and i ~= argidx then
       has_rev_arg = true
-      goto continue
+      break
     end
   end
-  ::continue::
 
   if argidx >= divideridx then
     return vim.fn.getcompletion(arg_lead, "file", 0)

--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -1,11 +1,6 @@
-DiffviewGlobal = {}
---[[
-Debug Levels:
-0:    NOTHING
-1:    NORMAL
-10:   RENDERING
---]]
-DiffviewGlobal.debug_level = tonumber(os.getenv("DEBUG_DIFFVIEW")) or 0
+if not require("diffview.bootstrap") then
+  return
+end
 
 local arg_parser = require("diffview.arg_parser")
 local lib = require("diffview.lib")

--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -103,7 +103,7 @@ function M.completion(arg_lead, cmd_line, cur_pos)
     local revs = vim.fn.systemlist(cmd .. "rev-parse --symbolic --branches --tags --remotes")
     local stashes = vim.fn.systemlist(cmd .. "stash list --pretty=format:%gd")
 
-    return filter_completion(arg_lead, utils.tbl_concat(heads, revs, stashes))
+    return filter_completion(arg_lead, utils.vec_join(heads, revs, stashes))
   else
     local flag_completion = flag_value_completion:get_completion(arg_lead)
     if flag_completion then

--- a/lua/diffview/api/views/diff/diff_view.lua
+++ b/lua/diffview/api/views/diff/diff_view.lua
@@ -20,12 +20,11 @@ local M = {}
 ---@field right_null boolean Indicates that the right buffer should be represented by the null buffer.
 ---@field selected boolean|nil Indicates that this should be the initially selected file.
 
----@class CDiffView
+---@class CDiffView : DiffView
 ---@field files any
 ---@field fetch_files function A function that should return an updated list of files.
 ---@field get_file_data function A function that is called with parameters `path: string` and `split: string`, and should return a list of lines that should make up the buffer.
-local CDiffView = DiffView
-CDiffView = oop.create_class("CDiffView", DiffView)
+local CDiffView = oop.create_class("CDiffView", DiffView)
 
 ---CDiffView constructor.
 ---@param opt any

--- a/lua/diffview/api/views/file_entry.lua
+++ b/lua/diffview/api/views/file_entry.lua
@@ -6,12 +6,11 @@ local api = vim.api
 
 local M = {}
 
----@class CFileEntry
+---@class CFileEntry : FileEntry
 ---@field left_null boolean
 ---@field right_null boolean
 ---@field get_file_data function
-local CFileEntry = FileEntry
-CFileEntry = oop.create_class("CFileEntry", FileEntry)
+local CFileEntry = oop.create_class("CFileEntry", FileEntry)
 
 ---CFileEntry constructor.
 ---@param opt any

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -5,12 +5,11 @@ local M = {}
 local short_flag_pat = "^%-(%a)=?(.*)"
 local long_flag_pat = "^%-%-(%a[%a%d-]*)=?(.*)"
 
----@class ArgObject
+---@class ArgObject : Object
 ---@field flags table<string, string>
 ---@field args string[]
 ---@field post_args string[]
-local ArgObject = oop.Object
-ArgObject = oop.create_class("ArgObject")
+local ArgObject = oop.create_class("ArgObject")
 
 ---ArgObject constructor.
 ---@param flags table<string, string>
@@ -33,10 +32,9 @@ function ArgObject:get_flag(...)
   end
 end
 
----@class FlagValueMap
+---@class FlagValueMap : Object
 ---@field map table<string, string[]>
-local FlagValueMap = oop.Object
-FlagValueMap = oop.create_class("FlagValueMap")
+local FlagValueMap = oop.create_class("FlagValueMap")
 
 ---FlagValueMap constructor
 ---@return FlagValueMap

--- a/lua/diffview/bootstrap.lua
+++ b/lua/diffview/bootstrap.lua
@@ -1,0 +1,37 @@
+if DiffviewGlobal and DiffviewGlobal.bootstrap_done then
+  return DiffviewGlobal.bootstrap_ok
+end
+
+local function err(msg)
+  msg = msg:gsub("'", "''")
+  vim.cmd("echohl Error")
+  vim.cmd(string.format("echom '%s'", msg))
+  vim.cmd("echohl NONE")
+end
+
+_G.DiffviewGlobal = {
+  bootstrap_done = true,
+  bootstrap_ok = false,
+}
+
+-- Ensure dependencies
+local ok = pcall(require, "plenary")
+if not ok then
+  err(
+    "[diffview.nvim] Dependency 'plenary.nvim' is not installed! "
+    .. "See ':h diffview.changelog-93' for more information."
+  )
+  return false
+end
+
+_G.DiffviewGlobal = {
+  ---Debug Levels:
+  ---0:    NOTHING
+  ---1:    NORMAL
+  ---10:   RENDERING
+  debug_level = tonumber(os.getenv("DEBUG_DIFFVIEW")) or 0,
+  bootstrap_done = true,
+  bootstrap_ok = true,
+}
+
+return true

--- a/lua/diffview/debounce.lua
+++ b/lua/diffview/debounce.lua
@@ -1,0 +1,78 @@
+local utils = require "diffview.utils"
+local M = {}
+
+---Debounces a function on the leading edge.
+---@param ms integer Timeout in ms
+---@param fn function Function to debounce
+---@returns function Debounced function.
+function M.debounce_leading(ms, fn)
+  local timer = vim.loop.new_timer()
+  local running = false
+  return function(...)
+    timer:start(ms, 0, function()
+      timer:stop()
+      running = false
+    end)
+    if not running then
+      running = true
+      fn(...)
+    end
+  end
+end
+
+---Debounces a function on the trailing edge.
+---@param ms integer Timeout in ms
+---@param fn function Function to debounce
+---@returns function Debounced function.
+function M.debounce_trailing(ms, fn)
+  local timer = vim.loop.new_timer()
+  return function(...)
+    local args = utils.tbl_pack(...)
+    timer:start(ms, 0, function()
+      timer:stop()
+      fn(utils.tbl_unpack(args))
+    end)
+  end
+end
+
+---Throttles a function on the leading edge.
+---@param ms integer Timeout in ms
+---@param fn function Function to throttle
+---@returns function throttled function.
+function M.throttle_leading(ms, fn)
+  local timer = vim.loop.new_timer()
+  local running = false
+  return function(...)
+    if not running then
+      timer:start(ms, 0, function()
+        running = false
+        timer:stop()
+      end)
+      running = true
+      fn(...)
+    end
+  end
+end
+
+---Throttles a function on the trailing edge.
+---@param ms integer Timeout in ms
+---@param fn function Function to throttle
+---@returns function throttled function.
+function M.throttle_trailing(ms, fn)
+  local timer = vim.loop.new_timer()
+  local running = false
+  local args
+  return function(...)
+    args = utils.tbl_pack(...)
+    if not running then
+      timer:start(ms, 0, function()
+        running = false
+        timer:stop()
+        fn(utils.tbl_unpack(args))
+      end)
+      running = true
+    end
+  end
+end
+
+return M

--- a/lua/diffview/diff.lua
+++ b/lua/diffview/diff.lua
@@ -17,7 +17,7 @@ local EditToken = oop.enum({
   "REPLACE",
 })
 
----@class Diff
+---@class Diff : Object
 ---@field a any[]
 ---@field b any[]
 ---@field moda boolean[]
@@ -25,8 +25,7 @@ local EditToken = oop.enum({
 ---@field up table<integer, integer>
 ---@field down table<integer, integer>
 ---@field eql_fn function
-local Diff = oop.Object
-Diff = oop.create_class("Diff")
+local Diff = oop.create_class("Diff")
 
 ---Diff constructor.
 ---@param a any[]

--- a/lua/diffview/events.lua
+++ b/lua/diffview/events.lua
@@ -10,10 +10,9 @@ local Event = oop.enum({
   "FILES_STAGED",
 })
 
----@class EventEmitter
+---@class EventEmitter : Object
 ---@field listeners table<Event, function[]>
-local EventEmitter = oop.Object
-EventEmitter = oop.create_class("EventEmitter")
+local EventEmitter = oop.create_class("EventEmitter")
 
 ---EventEmitter constructor.
 ---@return EventEmitter

--- a/lua/diffview/git/commit.lua
+++ b/lua/diffview/git/commit.lua
@@ -2,7 +2,7 @@ local oop = require("diffview.oop")
 local utils = require("diffview.utils")
 local M = {}
 
----@class Commit
+---@class Commit : Object
 ---@field hash string
 ---@field author string
 ---@field time number
@@ -11,8 +11,7 @@ local M = {}
 ---@field rel_date string
 ---@field subject string
 ---@field body string
-local Commit = oop.Object
-Commit = oop.create_class("Commit")
+local Commit = oop.create_class("Commit")
 
 function Commit:init(opt)
   self.hash = opt.hash

--- a/lua/diffview/git/file_dict.lua
+++ b/lua/diffview/git/file_dict.lua
@@ -3,13 +3,12 @@ local FileTree = require("diffview.views.file_tree.file_tree").FileTree
 local M = {}
 
 ---@type table<integer, FileEntry>
----@class FileDict
+---@class FileDict : Object
 ---@field working FileEntry[]
 ---@field staged FileEntry[]
 ---@field working_tree FileTree
 ---@field staged_tree FileTree
-local FileDict = oop.Object
-FileDict = oop.create_class("FileDict")
+local FileDict = oop.create_class("FileDict")
 
 ---FileDict constructor.
 ---@return FileDict

--- a/lua/diffview/git/log_entry.lua
+++ b/lua/diffview/git/log_entry.lua
@@ -1,7 +1,7 @@
 local oop = require("diffview.oop")
 local M = {}
 
----@class LogEntry
+---@class LogEntry : Object
 ---@field path_args string[]
 ---@field commit Commit
 ---@field files FileEntry[]
@@ -9,8 +9,7 @@ local M = {}
 ---@field stats GitStats
 ---@field single_file boolean
 ---@field folded boolean
-local LogEntry = oop.Object
-LogEntry = oop.create_class("LogEntry")
+local LogEntry = oop.create_class("LogEntry")
 
 function LogEntry:init(opt)
   self.path_args = opt.path_args

--- a/lua/diffview/git/rev.lua
+++ b/lua/diffview/git/rev.lua
@@ -15,12 +15,11 @@ local RevType = oop.enum({
   "CUSTOM",
 })
 
----@class Rev
+---@class Rev : Object
 ---@field type integer
 ---@field commit string A commit SHA.
 ---@field head boolean If true, indicates that the rev should be updated when HEAD changes.
-local Rev = oop.Object
-Rev = oop.create_class("Rev")
+local Rev = oop.create_class("Rev")
 
 ---Rev constructor
 ---@param type RevType

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -80,6 +80,7 @@ function M.file_history(args)
   local default_args = config.get_config().default_args.DiffviewFileHistory
   local argo = arg_parser.parse(vim.tbl_flatten({ default_args, args }))
   local paths = {}
+  local rel_paths
 
   for _, path in ipairs(argo.args) do
     table.insert(paths, vim.fn.expand(path))
@@ -94,6 +95,10 @@ function M.file_history(args)
     end
   end
 
+  rel_paths = vim.tbl_map(function(v)
+    return vim.fn.fnamemodify(v, ":.")
+  end, paths)
+
   local p
   if vim.fn.filereadable(paths[1]) == 1 then
     p = vim.fn.isdirectory(paths[1]) ~= 1 and vim.fn.fnamemodify(paths[1], ":h") or paths[1]
@@ -105,9 +110,7 @@ function M.file_history(args)
 
   local git_root = git.toplevel(p)
   if not git_root then
-    utils.err(
-      string.format("Path not a git repo (or any parent): '%s'", vim.fn.fnamemodify(paths[1], ":."))
-    )
+    utils.err( string.format("Path not a git repo (or any parent): '%s'", rel_paths[1]))
     return
   end
 
@@ -116,19 +119,21 @@ function M.file_history(args)
     return git.expand_pathspec(git_root, cwd, pathspec)
   end, paths)
 
+  local log_options = config.get_config().file_history_panel.log_options
+  local ok = git.file_history_dry_run(git_root, paths, log_options)
+
+  if not ok then
+    utils.info(string.format("No git history for target(s): '%s'", table.concat(rel_paths, ", ")))
+    return
+  end
+
   ---@type FileHistoryView
   local v = FileHistoryView({
     git_root = git_root,
     path_args = paths,
     raw_args = argo.args,
-    log_options = config.get_config().file_history_panel.log_options,
+    log_options = log_options,
   })
-
-  -- TODO: Find new way to do this now that entries are gathered asynchronously
-  -- if #v.entries == 0 then
-  --   utils.info(string.format("Target has no git history: '%s'", table.concat(paths)))
-  --   return
-  -- end
 
   table.insert(M.views, v)
 

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -124,10 +124,11 @@ function M.file_history(args)
     log_options = config.get_config().file_history_panel.log_options,
   })
 
-  if #v.entries == 0 then
-    utils.info(string.format("Target has no git history: '%s'", table.concat(paths)))
-    return
-  end
+  -- TODO: Find new way to do this now that entries are gathered asynchronously
+  -- if #v.entries == 0 then
+  --   utils.info(string.format("Target has no git history: '%s'", table.concat(paths)))
+  --   return
+  -- end
 
   table.insert(M.views, v)
 

--- a/lua/diffview/logger.lua
+++ b/lua/diffview/logger.lua
@@ -8,6 +8,11 @@ local logger = log.new({
   level = DiffviewGlobal.debug_level > 0 and "debug" or "error",
 })
 
+logger.outfile = string.format(
+  "%s/%s.log", vim.api.nvim_call_function("stdpath", { "cache" }),
+  logger.plugin
+)
+
 -- Add scheduled variants of the different log methods.
 for _, kind in ipairs({ "trace", "debug", "info", "warn", "error", "fatal" }) do
   logger["s_" .. kind] = vim.schedule_wrap(function (...)

--- a/lua/diffview/oop.lua
+++ b/lua/diffview/oop.lua
@@ -29,6 +29,9 @@ local function duplicate(t)
   return t2
 end
 
+---@generic T
+---@param class `T`
+---@return T
 local function new_instance(class, ...)
   ---@diagnostic disable-next-line: redefined-local
   local function make_instance(class, virtuals)

--- a/lua/diffview/perf.lua
+++ b/lua/diffview/perf.lua
@@ -72,10 +72,6 @@ function PerfTimer.__tostring(self)
   end
 end
 
-function PerfTimer:print()
-  utils._echo_multiline(tostring(self))
-end
-
 ---Get the relative performance difference in percent.
 ---@static
 ---@param a PerfTimer

--- a/lua/diffview/perf.lua
+++ b/lua/diffview/perf.lua
@@ -25,6 +25,7 @@ end
 function PerfTimer:reset()
   self.laps = {}
   self.first = luv.hrtime()
+  self.final_time = nil
 end
 
 ---Record a lap time.

--- a/lua/diffview/perf.lua
+++ b/lua/diffview/perf.lua
@@ -4,14 +4,13 @@ local utils = require("diffview.utils")
 local luv = vim.loop
 local M = {}
 
----@class PerfTimer
+---@class PerfTimer : Object
 ---@field subject string|nil
 ---@field first integer Start time (ns)
 ---@field last integer Stop time (ns)
 ---@field final_time number Final time (ms)
 ---@field laps number[] List of lap times (ms)
-local PerfTimer = oop.Object
-PerfTimer = oop.create_class("PerfTimer")
+local PerfTimer = oop.create_class("PerfTimer")
 
 ---PerfTimer constructor.
 ---@param subject string|nil

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -153,6 +153,18 @@ function RenderComponent:clear()
   end
 end
 
+function RenderComponent:destroy()
+  self.lines = nil
+  self.hl = nil
+  self.parent = nil
+  self.context = nil
+  self.data_root = nil
+  for _, c in ipairs(self.components) do
+    c:destroy()
+  end
+  self.components = nil
+end
+
 function RenderComponent:get_comp_on_line(line)
   line = line - 1
 
@@ -306,6 +318,25 @@ function RenderData:clear()
   self.hl = {}
   for _, c in ipairs(self.components) do
     c:clear()
+  end
+end
+
+function RenderData:destroy()
+  self.lines = nil
+  self.hl = nil
+  for _, c in ipairs(self.components) do
+    c:destroy()
+  end
+  self.components = {}
+end
+
+function M.destroy_comp_struct(schema)
+  schema.comp = nil
+  for k, v in pairs(schema) do
+    if type(v) == "table" then
+      M.destroy_comp_struct(v)
+      schema[k] = nil
+    end
   end
 end
 

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -2,9 +2,13 @@ local oop = require("diffview.oop")
 local utils = require("diffview.utils")
 local config = require("diffview.config")
 local api = vim.api
+
 local M = {}
 local web_devicons
 local uid_counter = 0
+
+---Duration of the last redraw in ms.
+M.last_draw_time = 0
 
 ---@class HlData
 ---@field group string
@@ -426,6 +430,7 @@ function M.render(bufid, data)
     return
   end
 
+  local last = vim.loop.hrtime()
   local was_modifiable = api.nvim_buf_get_option(bufid, "modifiable")
   api.nvim_buf_set_option(bufid, "modifiable", true)
 
@@ -458,6 +463,7 @@ function M.render(bufid, data)
   end
 
   api.nvim_buf_set_option(bufid, "modifiable", was_modifiable)
+  M.last_draw_time = (vim.loop.hrtime() - last) / 1000000
 end
 
 local git_status_hl_map = {

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -309,7 +309,7 @@ end
 ---components.
 ---@param components RenderComponent[]
 function M.create_cursor_constraint(components)
-  local stack = utils.tbl_slice(components, 1)
+  local stack = utils.vec_slice(components, 1)
   utils.merge_sort(stack, function(a, b)
     return a.lstart <= b.lstart
   end)

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -21,7 +21,7 @@ M.last_draw_time = 0
 ---@field comp RenderComponent
 local CompStruct
 
----@class RenderComponent
+---@class RenderComponent : Object
 ---@field name string
 ---@field parent RenderComponent
 ---@field lines string[]
@@ -33,8 +33,7 @@ local CompStruct
 ---@field leaf boolean
 ---@field data_root RenderData
 ---@field context any
-local RenderComponent = oop.Object
-RenderComponent = oop.create_class("RenderComponent")
+local RenderComponent = oop.create_class("RenderComponent")
 
 ---RenderComponent constructor.
 ---@return RenderComponent
@@ -247,13 +246,12 @@ function RenderComponent:pretty_print()
   recurse(0, self)
 end
 
----@class RenderData
+---@class RenderData : Object
 ---@field lines string[]
 ---@field hl HlData[]
 ---@field components RenderComponent[]
 ---@field namespace integer
-local RenderData = oop.Object
-RenderData = oop.create_class("RenderData")
+local RenderData = oop.create_class("RenderData")
 
 ---RenderData constructor.
 ---@return RenderData

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -161,11 +161,7 @@ function Panel:open()
   self.winid = api.nvim_get_current_win()
   self:resize()
   api.nvim_win_set_buf(self.winid, self.bufid)
-
-  for k, v in pairs(self.class().winopts) do
-    local opt = type(v) == "table" and v[2] or nil
-    utils.set_local(self.winid, k, type(v) == "table" and v[1] or v, opt)
-  end
+  utils.set_local(self.winid, self.class().winopts)
 end
 
 function Panel:close()

--- a/lua/diffview/ui/panel.lua
+++ b/lua/diffview/ui/panel.lua
@@ -20,7 +20,7 @@ local Form = oop.enum({
   "ROW",
 })
 
----@class Panel
+---@class Panel : Object
 ---@field position string
 ---@field form Form
 ---@field relative string
@@ -34,8 +34,7 @@ local Form = oop.enum({
 ---@field init_buffer_opts function Abstract
 ---@field update_components function Abstract
 ---@field render function Abstract
-local Panel = oop.Object
-Panel = oop.create_class("Panel")
+local Panel = oop.create_class("Panel")
 
 Panel.winopts = {
   relativenumber = false,

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -6,6 +6,7 @@ local mapping_callbacks = {}
 local path_sep = package.config:sub(1, 1)
 local setlocal_opr_templates = {
   set = [[setl ${option}=${value}]],
+  remove = [[exe 'setl ${option}-=${value}']],
   append = [[exe 'setl ${option}=' . (&${option} == "" ? "" : &${option} . ",") . '${value}']],
   prepend = [[exe 'setl ${option}=${value}' . (&${option} == "" ? "" : "," . &${option})]],
 }
@@ -304,7 +305,7 @@ end
 ---@param value string[]|string
 ---@param opt table
 ---`opt` fields:
----   - `method` ("set"|"append"|"prepend") Assignment method. (default: "set")
+---   - `method` '"set"'|'"remove"'|'"append"'|'"prepend"' Assignment method. (default: "set")
 function M.set_local(winids, option, value, opt)
   local cmd
   opt = vim.tbl_extend("keep", opt or {}, {
@@ -315,7 +316,10 @@ function M.set_local(winids, option, value, opt)
     cmd = string.format("setl %s%s", value and "" or "no", option)
   else
     value = (type(value) == "table" and table.concat(value, ",") or tostring(value)):gsub("'", "''")
-    cmd = M.str_template(setlocal_opr_templates[opt.method], { option = option, value = value })
+    cmd = M.str_template(
+      setlocal_opr_templates[opt.method],
+      { option = option, value = value or "" }
+    )
   end
 
   if type(winids) ~= "table" then
@@ -401,45 +405,6 @@ function M.tbl_deep_clone(t)
   return clone
 end
 
-function M.tbl_deep_equals(t1, t2)
-  if not (t1 and t2) then
-    return false
-  end
-
-  local function recurse(t11, t22)
-    if #t11 ~= #t22 then
-      return false
-    end
-
-    local seen = {}
-    for key, value in pairs(t11) do
-      seen[key] = true
-      if type(value) == "table" then
-        if type(t22[key]) ~= "table" then
-          return false
-        end
-        if not recurse(value, t22[key]) then
-          return false
-        end
-      else
-        if not (value == t22[key]) then
-          return false
-        end
-      end
-    end
-
-    for key, _ in pairs(t22) do
-      if not seen[key] then
-        return false
-      end
-    end
-
-    return true
-  end
-
-  return recurse(t1, t2)
-end
-
 function M.tbl_pack(...)
   return { n = select("#", ...), ... }
 end
@@ -461,6 +426,15 @@ function M.tbl_clear(t)
   for k, _ in pairs(t) do
     t[k] = nil
   end
+end
+
+function M.tbl_push(t, ...)
+  local args = M.tbl_pack(...)
+  local l = #t
+  for i, v in ipairs(args) do
+    t[l + i] = v
+  end
+  return t
 end
 
 function M.find_named_buffer(name)

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -14,23 +14,37 @@ local setlocal_opr_templates = {
   prepend = [[exe 'setl ${option}=${value}' . (&${option} == "" ? "" : "," . &${option})]],
 }
 
-function M._echo_multiline(msg, hl)
-  local chunks = vim.tbl_map(function(line)
-    return { line, hl }
-  end, vim.split(msg, "\n"))
-  vim.api.nvim_echo(chunks, true, {})
+function M._echo_multiline(msg, hl, schedule)
+  if schedule then
+    vim.schedule(function()
+      M._echo_multiline(msg, hl, false)
+    end)
+    return
+  end
+
+  vim.cmd("echohl " .. (hl or "None"))
+  for _, line in ipairs(vim.split(msg, "\n")) do
+    vim.cmd(string.format('echom "%s"', vim.fn.escape(line, [["\]])))
+  end
+  vim.cmd("echohl None")
 end
 
-function M.info(msg)
-  M._echo_multiline("[Diffview.nvim] " .. msg, "Directory")
+---@param msg string
+---@param schedule? boolean Schedule the echo call.
+function M.info(msg, schedule)
+  M._echo_multiline("[Diffview.nvim] " .. msg, "Directory", schedule)
 end
 
-function M.warn(msg)
-  M._echo_multiline("[Diffview.nvim] " .. msg, "WarningMsg")
+---@param msg string
+---@param schedule? boolean Schedule the echo call.
+function M.warn(msg, schedule)
+  M._echo_multiline("[Diffview.nvim] " .. msg, "WarningMsg", schedule)
 end
 
-function M.err(msg)
-  M._echo_multiline("[Diffview.nvim] " .. msg, "ErrorMsg")
+---@param msg string
+---@param schedule? boolean Schedule the echo call.
+function M.err(msg, schedule)
+  M._echo_multiline("[Diffview.nvim] " .. msg, "ErrorMsg", schedule)
 end
 
 ---Call the function `f`, ignoring most of the window and buffer related

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -17,7 +17,7 @@ local M = {}
 ---@class DiffViewOptions
 ---@field show_untracked boolean|nil
 
----@class DiffView
+---@class DiffView : StandardView
 ---@field git_root string Absolute path the root of the git directory.
 ---@field git_dir string Absolute path to the '.git' directory.
 ---@field rev_arg string
@@ -28,8 +28,7 @@ local M = {}
 ---@field panel FilePanel
 ---@field files FileDict
 ---@field file_idx integer
-local DiffView = StandardView
-DiffView = oop.create_class("DiffView", StandardView)
+local DiffView = oop.create_class("DiffView", StandardView)
 
 ---DiffView constructor
 ---@return DiffView

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -239,7 +239,7 @@ function DiffView:update_files()
   self.panel:render()
   self.panel:redraw()
 
-  if utils.tbl_indexof(self.panel:ordered_file_list(), self.panel.cur_file) == -1 then
+  if utils.vec_indexof(self.panel:ordered_file_list(), self.panel.cur_file) == -1 then
     self.panel.cur_file = nil
   end
   self:set_file(self.panel.cur_file or self.panel:next_file())

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -38,7 +38,7 @@ FilePanel.winopts = vim.tbl_extend("force", Panel.winopts, {
       "StatusLine:DiffviewStatusLine",
       "StatusLineNC:DiffviewStatuslineNC",
     }, ","),
-    { method = "prepend" },
+    opt = { method = "prepend" },
   },
 })
 

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -10,7 +10,7 @@ local M = {}
 ---@field flatten_dirs boolean
 ---@field folder_statuses "never"|"only_folded"|"always"
 
----@class FilePanel
+---@class FilePanel : Panel
 ---@field git_root string
 ---@field files FileDict
 ---@field path_args string[]
@@ -24,8 +24,7 @@ local M = {}
 ---@field render_data RenderData
 ---@field components any
 ---@field constrain_cursor function
-local FilePanel = Panel
-FilePanel = oop.create_class("FilePanel", Panel)
+local FilePanel = oop.create_class("FilePanel", Panel)
 
 FilePanel.winopts = vim.tbl_extend("force", Panel.winopts, {
   cursorline = true,

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -149,7 +149,7 @@ function FilePanel:ordered_file_list()
     end
     return list
   else
-    local nodes = utils.tbl_concat(
+    local nodes = utils.vec_join(
       self.files.working_tree.root:leaves(),
       self.files.staged_tree.root:leaves()
     )
@@ -170,7 +170,7 @@ function FilePanel:prev_file()
     return self.cur_file
   end
 
-  local i = utils.tbl_indexof(files, self.cur_file)
+  local i = utils.vec_indexof(files, self.cur_file)
   if i ~= -1 then
     self.cur_file = files[(i - 2) % #files + 1]
     return self.cur_file
@@ -184,7 +184,7 @@ function FilePanel:next_file()
     return self.cur_file
   end
 
-  local i = utils.tbl_indexof(files, self.cur_file)
+  local i = utils.vec_indexof(files, self.cur_file)
   if i ~= -1 then
     self.cur_file = files[i % #files + 1]
     return self.cur_file

--- a/lua/diffview/views/diff/render.lua
+++ b/lua/diffview/views/diff/render.lua
@@ -158,7 +158,7 @@ return function(panel)
   end
 
   if panel.rev_pretty_name or (panel.path_args and #panel.path_args > 0) then
-    local extra_info = utils.tbl_concat({ panel.rev_pretty_name }, panel.path_args or {})
+    local extra_info = utils.vec_join({ panel.rev_pretty_name }, panel.path_args or {})
 
     comp = panel.components.info.title.comp
     line_idx = 0

--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -348,7 +348,7 @@ function FileEntry._update_windows(left_winid, right_winid)
   -- Scroll to trigger the scrollbind and sync the windows. This works more
   -- consistently than calling `:syncbind`.
   api.nvim_win_call(right_winid, function()
-    vim.cmd([[exe "norm! \<c-y>"]])
+    vim.cmd([[exe "norm! \<c-e>\<c-y>"]])
   end)
 end
 

--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -335,9 +335,7 @@ end
 
 ---@static
 function FileEntry._update_windows(left_winid, right_winid)
-  for k, v in pairs(FileEntry.winopts) do
-    utils.set_local({ left_winid, right_winid }, k, v)
-  end
+  utils.set_local({ left_winid, right_winid }, FileEntry.winopts)
 
   for _, id in ipairs({ left_winid, right_winid }) do
     if id ~= api.nvim_get_current_win() then

--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -11,7 +11,7 @@ local fstat_cache = {}
 ---@field additions integer
 ---@field deletions integer
 
----@class FileEntry
+---@class FileEntry : Object
 ---@field path string
 ---@field oldpath string
 ---@field absolute_path string
@@ -29,8 +29,7 @@ local fstat_cache = {}
 ---@field left_bufid integer
 ---@field right_bufid integer
 ---@field created_bufs integer[]
-local FileEntry = oop.Object
-FileEntry = oop.create_class("FileEntry")
+local FileEntry = oop.create_class("FileEntry")
 
 ---@static
 ---@type integer|nil

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -139,7 +139,7 @@ end
 
 function FileHistoryPanel:update_entries()
   local throttled_update = debounce.throttle_trailing(100, vim.schedule_wrap(function(entries)
-    self.entries = utils.tbl_slice(entries)
+    self.entries = utils.vec_slice(entries)
     self:update_components()
     self:render()
     self:redraw()
@@ -227,8 +227,8 @@ function FileHistoryPanel:prev_file()
   end
 
   if self:num_items() > 1 then
-    local entry_idx = utils.tbl_indexof(self.entries, entry)
-    local file_idx = utils.tbl_indexof(entry.files, file)
+    local entry_idx = utils.vec_indexof(self.entries, entry)
+    local file_idx = utils.vec_indexof(entry.files, file)
     if entry_idx ~= -1 and file_idx ~= -1 then
       if file_idx == 1 and #self.entries > 1 then
         -- go to prev entry
@@ -259,8 +259,8 @@ function FileHistoryPanel:next_file()
   end
 
   if self:num_items() > 1 then
-    local entry_idx = utils.tbl_indexof(self.entries, entry)
-    local file_idx = utils.tbl_indexof(entry.files, file)
+    local entry_idx = utils.vec_indexof(self.entries, entry)
+    local file_idx = utils.vec_indexof(entry.files, file)
     if entry_idx ~= -1 and file_idx ~= -1 then
       if file_idx == #entry.files and #self.entries > 1 then
         -- go to next entry
@@ -294,7 +294,7 @@ function FileHistoryPanel:highlight_item(item)
     end
   else
     for _, comp_struct in ipairs(self.components.log.entries) do
-      local i = utils.tbl_indexof(comp_struct.comp.context.files, item)
+      local i = utils.vec_indexof(comp_struct.comp.context.files, item)
       if i ~= -1 then
         if self.single_file then
           pcall(api.nvim_win_set_cursor, self.winid, { comp_struct.comp.lstart + 1, 0 })

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -165,7 +165,12 @@ function FileHistoryPanel:update_entries(callback)
   local update = debounce.throttle_trailing(
     timeout,
     function(entries, status)
-      if status > 0 and (#entries <= c or lock) then
+      if status == 2 then
+        utils.err("Updating file history failed!")
+        self.updating = false
+        callback(nil, 2)
+        return
+      elseif status == 1 and (#entries <= c or lock) then
         return
       end
 

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -102,6 +102,19 @@ function FileHistoryPanel:open()
   vim.cmd("wincmd =")
 end
 
+---@Override
+function FileHistoryPanel:destroy()
+  self.entries = nil
+  self.cur_item = nil
+  self.option_panel:destroy()
+  self.option_panel = nil
+  self.render_data:destroy()
+  if self.components then
+    renderer.destroy_comp_struct(self.components)
+  end
+  FileHistoryPanel:super().destroy(self)
+end
+
 function FileHistoryPanel:init_buffer_opts()
   local conf = config.get_config()
   local option_rhs = config.diffview_callback("options")
@@ -115,6 +128,11 @@ function FileHistoryPanel:init_buffer_opts()
 end
 
 function FileHistoryPanel:update_components()
+  self.render_data:destroy()
+  if self.components then
+    renderer.destroy_comp_struct(self.components)
+  end
+
   local entry_schema = {}
   for _, entry in ipairs(self.entries) do
     table.insert(entry_schema, {

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -25,7 +25,7 @@ local perf = PerfTimer("[FileHistoryPanel] render")
 ---@field author string
 ---@field grep string
 
----@class FileHistoryPanel
+---@class FileHistoryPanel : Panel
 ---@field git_root string
 ---@field entries LogEntry[]
 ---@field path_args string[]
@@ -43,8 +43,7 @@ local perf = PerfTimer("[FileHistoryPanel] render")
 ---@field option_mapping string
 ---@field components any
 ---@field constrain_cursor function
-local FileHistoryPanel = Panel
-FileHistoryPanel = oop.create_class("FileHistoryPanel", Panel)
+local FileHistoryPanel = oop.create_class("FileHistoryPanel", Panel)
 
 FileHistoryPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
   cursorline = true,

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -16,7 +16,6 @@ local M = {}
 ---@field panel FileHistoryPanel
 ---@field path_args string[]
 ---@field raw_args string[]
----@field entries LogEntry[]
 local FileHistoryView = StandardView
 FileHistoryView = oop.create_class("FileHistoryView", StandardView)
 
@@ -30,7 +29,6 @@ function FileHistoryView:init(opt)
   self.git_dir = git.git_dir(self.git_root)
   self.path_args = opt.path_args
   self.raw_args = opt.raw_args
-  self.entries = {}
   self.panel = FileHistoryPanel(
     self.git_root,
     {},
@@ -45,7 +43,6 @@ function FileHistoryView:post_open()
   vim.schedule(function()
     self:file_safeguard()
     self.panel:update_entries(function(entries, status)
-      self.entries = self.panel.entries
       if not self.panel:cur_file() then
         local file = self.panel:next_file()
         if file then
@@ -59,7 +56,7 @@ end
 
 ---@Override
 function FileHistoryView:close()
-  for _, entry in ipairs(self.entries) do
+  for _, entry in ipairs(self.panel.entries) do
     entry:destroy()
   end
   FileHistoryView:super().close(self)

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -43,16 +43,17 @@ end
 function FileHistoryView:post_open()
   self:init_event_listeners()
   vim.schedule(function()
-    self.panel:update_entries()
-    self.entries = self.panel.entries
-    vim.cmd("redraw")
-    local file = self.panel:next_file()
-    if file then
-      self:set_file(file)
-    else
-      self:file_safeguard()
-    end
-    self.ready = true
+    self:file_safeguard()
+    self.panel:update_entries(function(entries, status)
+      self.entries = self.panel.entries
+      if not self.panel:cur_file() then
+        local file = self.panel:next_file()
+        if file then
+          self:set_file(file)
+        end
+        self.ready = true
+      end
+    end)
   end)
 end
 

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -42,8 +42,9 @@ function FileHistoryView:post_open()
   self:init_event_listeners()
   vim.schedule(function()
     self:file_safeguard()
+    ---@diagnostic disable-next-line: unused-local
     self.panel:update_entries(function(entries, status)
-      if not self.panel:cur_file() then
+      if status < 2 and not self.panel:cur_file() then
         local file = self.panel:next_file()
         if file then
           self:set_file(file)

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -6,6 +6,7 @@ local StandardView = require("diffview.views.standard.standard_view").StandardVi
 local LayoutMode = require("diffview.views.view").LayoutMode
 local FileEntry = require("diffview.views.file_entry").FileEntry
 local FileHistoryPanel = require("diffview.views.file_history.file_history_panel").FileHistoryPanel
+local JobStatus = git.JobStatus
 local api = vim.api
 
 local M = {}
@@ -43,14 +44,14 @@ function FileHistoryView:post_open()
     self:file_safeguard()
     ---@diagnostic disable-next-line: unused-local
     self.panel:update_entries(function(entries, status)
-      if status < 2 and not self.panel:cur_file() then
+      if status < JobStatus.ERROR and not self.panel:cur_file() then
         local file = self.panel:next_file()
         if file then
           self:set_file(file)
         end
-        self.ready = true
       end
     end)
+    self.ready = true
   end)
 end
 

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -17,7 +17,6 @@ local M = {}
 ---@field path_args string[]
 ---@field raw_args string[]
 ---@field entries LogEntry[]
----@field file_idx integer
 local FileHistoryView = StandardView
 FileHistoryView = oop.create_class("FileHistoryView", StandardView)
 
@@ -31,11 +30,10 @@ function FileHistoryView:init(opt)
   self.git_dir = git.git_dir(self.git_root)
   self.path_args = opt.path_args
   self.raw_args = opt.raw_args
-  self.entries = git.file_history_list(self.git_root, self.path_args, opt.log_options)
-  self.file_idx = 1
+  self.entries = {}
   self.panel = FileHistoryPanel(
     self.git_root,
-    self.entries,
+    {},
     self.path_args,
     self.raw_args,
     opt.log_options
@@ -45,6 +43,9 @@ end
 function FileHistoryView:post_open()
   self:init_event_listeners()
   vim.schedule(function()
+    self.panel:update_entries()
+    self.entries = self.panel.entries
+    vim.cmd("redraw")
     local file = self.panel:next_file()
     if file then
       self:set_file(file)

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -10,14 +10,13 @@ local api = vim.api
 
 local M = {}
 
----@class FileHistoryView
+---@class FileHistoryView : StandardView
 ---@field git_root string
 ---@field git_dir string
 ---@field panel FileHistoryPanel
 ---@field path_args string[]
 ---@field raw_args string[]
-local FileHistoryView = StandardView
-FileHistoryView = oop.create_class("FileHistoryView", StandardView)
+local FileHistoryView = oop.create_class("FileHistoryView", StandardView)
 
 function FileHistoryView:init(opt)
   self.emitter = EventEmitter()

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -46,6 +46,7 @@ return function(view)
           vim.schedule(function ()
             op.option_state = nil
             view.panel.option_panel.winid = nil
+            ---@diagnostic disable-next-line: unused-local
             view.panel:update_entries(function(entries, status)
               if not view.panel:cur_file() then
                 view:next_item()

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -42,11 +42,14 @@ return function(view)
     win_closed = function(winid)
       if winid and winid == view.panel.option_panel.winid then
         local op = view.panel.option_panel
-        if not utils.tbl_deep_equals(op.option_state, view.panel.log_options) then
-          op.option_state = nil
-          view.panel.option_panel.winid = nil
-          view.panel:update_entries()
-          view:next_item()
+        if not vim.deep_equal(op.option_state, view.panel.log_options) then
+          vim.schedule(function ()
+            op.option_state = nil
+            view.panel.option_panel.winid = nil
+            view.panel:update_entries()
+            vim.cmd("redraw")
+            view:next_item()
+          end)
         end
       end
     end,

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -46,9 +46,11 @@ return function(view)
           vim.schedule(function ()
             op.option_state = nil
             view.panel.option_panel.winid = nil
-            view.panel:update_entries()
-            vim.cmd("redraw")
-            view:next_item()
+            view.panel:update_entries(function(entries, status)
+              if not view.panel:cur_file() then
+                view:next_item()
+              end
+            end)
           end)
         end
       end

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -6,14 +6,13 @@ local EventEmitter = require("diffview.events").EventEmitter
 local api = vim.api
 local M = {}
 
----@class FHOptionPanel
+---@class FHOptionPanel : Panel
 ---@field parent FileHistoryPanel
 ---@field emitter EventEmitter
 ---@field render_data RenderData
 ---@field option_state LogOptions
 ---@field components any
-local FHOptionPanel = Panel
-FHOptionPanel = oop.create_class("FHOptionPanel", Panel)
+local FHOptionPanel = oop.create_class("FHOptionPanel", Panel)
 
 FHOptionPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
   cursorline = true,

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -84,6 +84,7 @@ local function render_entries(parent, entries)
   end
 
   for i, entry in ipairs(entries) do
+    if i > #parent then break end
     if not entry.status then
       print(vim.inspect(entry, { depth = 2 }))
     end

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -85,7 +85,7 @@ local function render_entries(parent, entries, updating)
   end
 
   for i, entry in ipairs(entries) do
-    if i > #parent or (updating and i > 200) then
+    if i > #parent or (updating and i > 128) then
       break
     end
     if not entry.status then

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -222,7 +222,9 @@ return {
       -- file path
       local icon = renderer.get_file_icon(file.basename, file.extension, comp, line_idx, 0)
       offset = #icon
-      comp:add_hl("DiffviewFilePanelPath", line_idx, offset, offset + #file.parent_path + 1)
+      if #file.parent_path > 0 then
+        comp:add_hl("DiffviewFilePanelPath", line_idx, offset, offset + #file.parent_path + 1)
+      end
       comp:add_hl(
         "DiffviewFilePanelFileName",
         line_idx,

--- a/lua/diffview/views/file_tree/file_tree.lua
+++ b/lua/diffview/views/file_tree/file_tree.lua
@@ -9,10 +9,9 @@ local M = {}
 ---@field collapsed boolean
 ---@field status string
 
----@class FileTree
+---@class FileTree : Object
 ---@field root Node
-local FileTree = oop.Object
-FileTree = oop.create_class("FileTree")
+local FileTree = oop.create_class("FileTree")
 
 ---FileTree constructor
 ---@param files FileEntry[]|nil

--- a/lua/diffview/views/file_tree/node.lua
+++ b/lua/diffview/views/file_tree/node.lua
@@ -2,13 +2,12 @@ local oop = require("diffview.oop")
 local utils = require("diffview.utils")
 local M = {}
 
----@class Node
+---@class Node : Object
 ---@field name string
 ---@field data any
 ---@field children Node[]
 ---@field depth integer|nil
-local Node = oop.Object
-Node = oop.create_class("Node")
+local Node = oop.create_class("Node")
 
 ---Node constructor
 ---@param name string

--- a/lua/diffview/views/standard/standard_view.lua
+++ b/lua/diffview/views/standard/standard_view.lua
@@ -9,14 +9,13 @@ local api = vim.api
 
 local M = {}
 
----@class StandardView
+---@class StandardView : View
 ---@field panel Panel
 ---@field winopts table
 ---@field left_winid integer
 ---@field right_winid integer
 ---@field nulled boolean
-local StandardView = View
-StandardView = oop.create_class("StandardView", View)
+local StandardView = oop.create_class("StandardView", View)
 
 ---StandardView constructor
 ---@return StandardView

--- a/lua/diffview/views/standard/standard_view.lua
+++ b/lua/diffview/views/standard/standard_view.lua
@@ -59,13 +59,8 @@ function StandardView:post_layout()
 end
 
 function StandardView:update_windows()
-  for k, v in pairs(self.winopts.left) do
-    utils.set_local(self.left_winid, k, v)
-  end
-
-  for k, v in pairs(self.winopts.right) do
-    utils.set_local(self.right_winid, k, v)
-  end
+  utils.set_local(self.left_winid, self.winopts.left)
+  utils.set_local(self.right_winid, self.winopts.right)
 end
 
 ---@Override

--- a/lua/diffview/views/view.lua
+++ b/lua/diffview/views/view.lua
@@ -14,7 +14,7 @@ local LayoutMode = oop.enum({
   "VERTICAL",
 })
 
----@class View
+---@class View : Object
 ---@field tabpage integer
 ---@field emitter EventEmitter
 ---@field layout_mode LayoutMode
@@ -23,8 +23,7 @@ local LayoutMode = oop.enum({
 ---@field post_open function Abstract
 ---@field validate_layout function Abstract
 ---@field recover_layout function Abstract
-local View = oop.Object
-View = oop.create_class("View")
+local View = oop.create_class("View")
 
 View:virtual("init_layout")
 View:virtual("post_open")

--- a/plugin/diffview.vim
+++ b/plugin/diffview.vim
@@ -1,5 +1,9 @@
 if !has('nvim-0.5') || exists('g:diffview_nvim_loaded') | finish | endif
 
+if !luaeval("require('diffview.bootstrap')")
+    finish
+endif
+
 command! -complete=customlist,s:completion -nargs=* DiffviewOpen lua require'diffview'.open(<f-args>)
 command! -complete=file -nargs=* DiffviewFileHistory lua require'diffview'.file_history(<f-args>)
 command! -bar -nargs=0 DiffviewClose lua require'diffview'.close()


### PR DESCRIPTION
File history currently takes a significant time to process the git log before it can open, and while it's doing this the editor is blocked. This PR makes use of lua coroutines and plenary jobs to make file history fully async. Not only does this make the processing non-blocking, but this implementation also processes the data incrementally such that results will be available relatively quickly regardless of how many commits are requested. This lets the editor remain responsive while the update is in progress.

## What will break?

The plugin will from here on out require [plenary.nvim](https://github.com/nvim-lua/plenary.nvim).

https://user-images.githubusercontent.com/2786478/141321078-a3d56e50-4858-4229-8402-9ba8b602bda8.mp4