### PR TITLE
Path library

### DIFF
--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -74,8 +74,8 @@ function M.completion(arg_lead, cmd_line, cur_pos)
   local args, argidx, divideridx = arg_parser.scan_ex_args(cmd_line, cur_pos)
   local fpath = (
       vim.bo.buftype == ""
-        and vim.fn.filereadable(vim.fn.expand("%"))
-        and vim.fn.expand("%:p:h")
+        and utils.path:readable(utils.path:vim_expand("%"))
+        and utils.path:vim_expand("%:p:h")
       or "."
     )
   local git_dir = require("diffview.git.utils").git_dir(fpath)
@@ -100,7 +100,7 @@ function M.completion(arg_lead, cmd_line, cur_pos)
     local heads = vim.tbl_filter(
       function(name) return vim.tbl_contains(targets, name) end,
       vim.tbl_map(
-        function(v) return vim.fn.fnamemodify(v, ":t") end,
+        function(v) return utils.path:basename(v) end,
         vim.fn.glob(git_dir .. "/*", false, true)
       )
     )

--- a/lua/diffview/api/views/diff/diff_view.lua
+++ b/lua/diffview/api/views/diff/diff_view.lua
@@ -123,7 +123,7 @@ function CDiffView:create_file_entries(files)
         CFileEntry({
           path = file_data.path,
           oldpath = file_data.oldpath,
-          absolute_path = utils.path_join({ self.git_root, file_data.path }),
+          absolute_path = utils.path:join(self.git_root, file_data.path),
           status = file_data.status,
           stats = file_data.stats,
           kind = v.kind,

--- a/lua/diffview/api/views/file_entry.lua
+++ b/lua/diffview/api/views/file_entry.lua
@@ -180,7 +180,10 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
   end
 
   -- stylua: ignore
-  local fullname = utils.path_join({ "diffview://", git_root, ".git", context, path, })
+  local fullname = "diffview://" .. utils.path_to_os(
+    utils.path_join({ git_root, ".git", context, path }),
+    "unix"
+  )
   for option, value in pairs(FileEntry.bufopts) do
     api.nvim_buf_set_option(bn, option, value)
   end
@@ -191,7 +194,10 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
     local i = 1
     while not ok do
       -- stylua: ignore
-      fullname = utils.path_join({ "diffview://", git_root, ".git", context, i, path, })
+      fullname = "diffview://" .. utils.path_to_os(
+        utils.path_join({ git_root, ".git", context, i, path }),
+        "unix"
+      )
       ok = pcall(api.nvim_buf_set_name, bn, fullname)
       i = i + 1
     end

--- a/lua/diffview/api/views/file_entry.lua
+++ b/lua/diffview/api/views/file_entry.lua
@@ -180,10 +180,7 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
   end
 
   -- stylua: ignore
-  local fullname = "diffview://" .. utils.path_to_os(
-    utils.path_join({ git_root, ".git", context, path }),
-    "unix"
-  )
+  local fullname = "diffview://" .. utils.path:join(git_root, ".git", context, path)
   for option, value in pairs(FileEntry.bufopts) do
     api.nvim_buf_set_option(bn, option, value)
   end
@@ -194,10 +191,7 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
     local i = 1
     while not ok do
       -- stylua: ignore
-      fullname = "diffview://" .. utils.path_to_os(
-        utils.path_join({ git_root, ".git", context, i, path }),
-        "unix"
-      )
+      fullname = "diffview://" .. utils.path:join(git_root, ".git", context, i, path)
       ok = pcall(api.nvim_buf_set_name, bn, fullname)
       i = i + 1
     end

--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -107,6 +107,8 @@ local tracked_files = async.void(function(git_root, left, right, args, kind, cal
       name = name:gsub("^.*\t", "")
     end
 
+    name = utils.path_to_os(name)
+
     local stats = {
       additions = tonumber(numstat_out[i]:match("^%d+")),
       deletions = tonumber(numstat_out[i]:match("^%d+%s+(%d+)")),
@@ -144,11 +146,12 @@ local untracked_files = async.void(function(git_root, left, right, callback)
       if j.code == 0 then
         local files = {}
         for _, s in ipairs(j:result()) do
+          local path = utils.path_to_os(s)
           table.insert(
             files,
             FileEntry({
-              path = s,
-              absolute_path = utils.path_join({ git_root, s }),
+              path = path,
+              absolute_path = utils.path_join({ git_root, path }),
               status = "?",
               kind = "working",
               left = left,
@@ -547,6 +550,8 @@ local function process_file_history(thread, git_root, path_args, opt, callback)
           old_path = oldname
         end
       end
+
+      name = utils.path_to_os(name)
 
       local stats = {
         additions = tonumber(cur.numstat[i]:match("^%d+")),

--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -1,0 +1,404 @@
+local oop = require("diffview.oop")
+
+local M = {}
+
+local uv = vim.loop
+local is_windows = jit.os == "Windows"
+
+---@class PathLib
+---@field sep '"/"'|'"\\\\"'
+---@field os '"unix"'|'"windows"' Determines the type of paths we're dealing with.
+---@field cwd string Leave as `nil` to always use current cwd.
+local PathLib = oop.create_class("PathLib")
+
+function PathLib:init(o)
+  self.sep = o.separator or package.config:sub(1, 1)
+  self.os = o.os or (is_windows and "windows" or "unix")
+  self._is_windows = self.os == "windows"
+  self.cwd = o.cwd and self:convert(o.cwd) or nil
+end
+
+function PathLib:_cwd()
+  return self.cwd or self:convert(uv.cwd())
+end
+
+---@return string
+function PathLib:_clean(...)
+  local argc = select("#", ...)
+  if argc == 1 and select(1, ...) ~= nil then
+    return self:convert(...)
+  end
+  local paths = { ... }
+  for i = 1, argc do
+    if paths[i] ~= nil then
+      paths[i] = self:convert(paths[i])
+    end
+  end
+  return unpack(paths)
+end
+
+---Check if a given path is a URI.
+---@param path string
+---@return boolean
+function PathLib:is_uri(path)
+  return string.match(path, "^%w+://") ~= nil
+end
+
+---Change the path separators in a path. Removes duplicate separators.
+---@param path string
+---@param sep? '"/"'|'"\\\\"'
+---@return string
+function PathLib:convert(path, sep)
+  sep = sep or self.sep
+  local scheme, p = "", tostring(path)
+  if self:is_uri(path) then
+    scheme, p = path:match("^(%w+://)(.*)")
+  end
+  p, _ = p:gsub("[\\/]+", sep)
+  return scheme .. p
+end
+
+---Convert a path to use the appropriate path separators for the current OS.
+---@param path string
+---@return string
+function PathLib:to_os(path)
+  return self:convert(path, self._is_windows and "\\" or "/")
+end
+
+---Check if a given path is absolute.
+---@param path string
+---@return boolean
+function PathLib:is_abs(path)
+  path = self:_clean(path)
+  if self._is_windows then
+    return path:match("^[A-Z]:") ~= nil
+  else
+    return path:sub(1, 1) == self.sep
+  end
+end
+
+---Get the absolute path of a given path. This is resolved using either the
+---`cwd` field if it's defined. Otherwise the current cwd is used instead.
+---@param path string
+---@param cwd? string
+---@return string
+function PathLib:absolute(path, cwd)
+  path, cwd = self:_clean(path, cwd)
+  cwd = cwd or self:_cwd()
+  if self:is_uri(path) then
+    return path
+  end
+  if self:is_abs(path) then
+    return self:normalize(path, { cwd = cwd, absolute = true })
+  end
+  return self:normalize(self:join(cwd, path), { cwd = cwd, absolute = true })
+end
+
+---Check if the given path is the root.
+---@param path string
+---@return boolean
+function PathLib:is_root(path)
+  path = self:_clean(path)
+  if self:is_abs(path) then
+    if self._is_windows then
+      return path:match(("^([A-Z]:%s?$)"):format(vim.pesc(self.sep))) ~= nil
+    else
+      return path == self.sep
+    end
+  end
+  return false
+end
+
+---Get the root of an absolute path. Returns nil if the path is not absolute.
+---@param path string
+---@return string|nil
+function PathLib:root(path)
+  path = tostring(path)
+  if self:is_abs(path) then
+    if self._is_windows then
+      return path:match("^([A-Z]:)")
+    else
+      return self.sep
+    end
+  end
+end
+
+---@class PathLibNormalizeSpec
+---@field cwd string
+---@field absolute boolean
+
+---Normalize a given path, resolving relative segments.
+---@param path string
+---@param opt? PathLibNormalizeSpec
+---@return string
+function PathLib:normalize(path, opt)
+  path = self:_clean(path)
+  if self:is_uri(path) then
+    return path
+  end
+
+  opt = opt or {}
+  local cwd = opt.cwd and self:_clean(opt.cwd) or self:_cwd()
+  local absolute = vim.F.if_nil(opt.absolute, false)
+
+  local root = self:root(path)
+  if root and self:is_root(path) then
+    return path
+  end
+
+  if not self:is_abs(path) then
+    local relpath = self:relative(path, cwd, true)
+    path = self:add_trailing(cwd) .. relpath
+  end
+
+  local parts = self:explode(path)
+  if root then
+    table.remove(parts, 1)
+  end
+
+  local normal = path
+  if #parts > 1 then
+    local i = 2
+    local upc = 0
+    repeat
+      if parts[i] == "." then
+        table.remove(parts, i)
+        i = i - 1
+      elseif parts[i] == ".." then
+        if i == 1 then
+          upc = upc + 1
+        end
+        table.remove(parts, i)
+        if i > 1 then
+          table.remove(parts, i - 1)
+          i = i - 2
+        else
+          i = i - 1
+        end
+      end
+
+      i = i + 1
+    until i > #parts
+
+    normal = self:join(root, unpack(parts))
+    if not absolute and upc == 0 then
+      normal = self:relative(normal, cwd, true)
+    end
+  end
+
+  return normal == "" and "." or normal
+end
+
+---Joins an ordered list of path segments into a path string.
+---@vararg ... string|string[] Paths
+---@return string
+function PathLib:join(...)
+  local segments = { ... }
+  if type(segments[1]) == "table" then
+    segments = segments[1]
+  end
+  segments = { self:_clean(unpack(segments)) }
+  local argc = select("#", unpack(segments))
+  local result = ""
+  if not self._is_windows and segments[1] == self.sep then
+    result = self.sep
+  end
+  local segc = 0
+  for i = result == "" and 1 or 2, argc do
+    if segments[i] ~= nil and segments[i] ~= "" then
+      result = result
+      .. (segc > 0 and self.sep or "")
+      .. string.match(segments[i], [[^(.-)[/\]?$]])
+      segc = segc + 1
+    end
+  end
+  return result
+end
+
+---Explodes the path into an ordered list of path segments.
+---@param path string
+---@return string[]
+function PathLib:explode(path)
+  path = self:_clean(path)
+  local parts = {}
+  local root = self:root(path)
+  if root then
+    parts[1] = root
+    if self._is_windows then
+      path = path:sub(#root + #self.sep + 1, -1)
+    else
+      path = path:sub(#root + 1, -1)
+    end
+  end
+  for part in path:gmatch(string.format("([^%s]+)%s?", self.sep, self.sep)) do
+    parts[#parts+1] = part
+  end
+  return parts
+end
+
+---Add a trailing separator, unless already present.
+---@param path string
+---@return string
+function PathLib:add_trailing(path)
+  path = tostring(path)
+  if path:sub(-1) == self.sep then
+    return path
+  end
+
+  return path .. self.sep
+end
+
+---Remove any trailing separator, if present.
+---@param path string
+---@return string
+function PathLib:remove_trailing(path)
+  path = tostring(path)
+  local p, _ = path:gsub(self.sep .. "$", "")
+  return p
+end
+
+---Get the basename of the given path.
+---@param path string
+---@return string
+function PathLib:basename(path)
+  path = self:remove_trailing(self:_clean(path))
+  local i = path:match("^.*()" .. self.sep)
+  if not i then
+    return path
+  end
+  return path:sub(i + 1, #path)
+end
+
+---Get the extension of the given path.
+---@param path string
+---@return string|nil
+function PathLib:extension(path)
+  path = self:basename(path)
+  return path:match(".+%.(.*)")
+end
+
+---Get the path to the parent directory of the given path. Returns `nil` if the
+---path has no parent.
+---@param path string
+---@param n integer Nth parent. (default: 1)
+---@return string|nil
+function PathLib:parent(path, n)
+  if type(n) ~= "number" or n < 1 then
+    n = 1
+  end
+  local parts = self:explode(path)
+  local root = self:root(path)
+  if root and n == #parts then
+    return root
+  elseif n >= #parts then
+    return
+  end
+  return self:join(unpack(parts, 1, #parts - n))
+end
+
+---Get a path relative to another path.
+---@param path string
+---@param relative_to string
+---@param no_resolve? boolean Don't normalize paths first.
+---@return string
+function PathLib:relative(path, relative_to, no_resolve)
+  path, relative_to = self:_clean(path, relative_to)
+  if not no_resolve then
+    local abs = self:is_abs(path)
+    path = self:normalize(path, { absolute = abs })
+    relative_to = self:normalize(relative_to, { absolute = abs })
+  end
+  if relative_to == "" then
+    return path
+  elseif relative_to == path then
+    return ""
+  end
+  local p, _ = path:gsub("^" .. vim.pesc(self:add_trailing(relative_to)), "")
+  return p
+end
+
+---Shotren a path by truncating the head.
+---@param path string
+---@param max_length integer
+---@return string
+function PathLib:shorten(path, max_length)
+  path = self:_clean(path)
+  if #path > max_length - 1 then
+    path = path:sub(#path - max_length + 1, #path)
+    local i = path:match("()" .. self.sep)
+    if not i then
+      return "…" .. path
+    end
+    return "…" .. path:sub(i, -1)
+  else
+    return path
+  end
+end
+
+---@param path string
+---@return string|nil
+function PathLib:realpath(path)
+  local p = uv.fs_realpath(path)
+  if p then
+    return self:convert(p)
+  end
+end
+
+---@param path string
+---@return string|nil
+function PathLib:readlink(path)
+  local p = uv.fs_readlink(path)
+  if p then
+    return self:convert(p)
+  end
+end
+
+---@param path string
+---@return string
+function PathLib:vim_expand(path)
+  return self:convert(vim.fn.expand(path))
+end
+
+---@param path string
+---@return string
+function PathLib:vim_fnamemodify(path, mods)
+  return self:convert(vim.fn.fnamemodify(path, mods))
+end
+
+---@param path string
+---@return table|nil
+function PathLib:stat(path)
+  return uv.fs_stat(path)
+end
+
+---@param path string
+---@return string|nil
+function PathLib:type(path)
+  local p = uv.fs_realpath(path)
+  if p then
+    local stat = uv.fs_stat(p)
+    if stat then
+      return stat.type
+    end
+  end
+end
+
+---@param path string
+---@return boolean
+function PathLib:is_directory(path)
+  return self:type(path) == "directory"
+end
+
+---Check for read access to a given path.
+---@param path string
+---@return boolean
+function PathLib:readable(path)
+  local p = uv.fs_realpath(path)
+  if p then
+    return uv.fs_access(p, "R")
+  end
+  return false
+end
+
+M.PathLib = PathLib
+return M

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -131,6 +131,21 @@ function M.pattern_esc(s)
   return result
 end
 
+---Convert a given path to the correct OS format.
+---@param path string
+---@param platform? '"unix"'|'"windows"'
+---@return string
+function M.path_to_os(path, platform)
+  platform = platform or (is_windows and "windows")
+  if platform == "windows" then
+    path, _ = path:gsub("/", "\\")
+    return path
+  else
+    path, _ = path:gsub("\\", "/")
+    return path
+  end
+end
+
 ---Check if a given path is absolute.
 ---@param path string
 ---@return boolean

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -1,11 +1,12 @@
 local Job = require("plenary.job")
+local PathLib = require("diffview.path").PathLib
 local async = require("plenary.async")
+
 local api = vim.api
 local M = {}
 
 ---@alias vector any[]
 
-local is_windows = jit.os == "Windows"
 local mapping_callbacks = {}
 local path_sep = package.config:sub(1, 1)
 local setlocal_opr_templates = {
@@ -14,6 +15,9 @@ local setlocal_opr_templates = {
   append = [[exe 'setl ${option}=' . (&${option} == "" ? "" : &${option} . ",") . '${value}']],
   prepend = [[exe 'setl ${option}=${value}' . (&${option} == "" ? "" : "," . &${option})]],
 }
+
+---@type PathLib
+M.path = PathLib({ separator = "/" })
 
 ---Echo string with multiple lines.
 ---@param msg string|string[]
@@ -129,128 +133,6 @@ function M.pattern_esc(s)
     ["$"] = "%$",
   })
   return result
-end
-
----Convert a given path to the correct OS format.
----@param path string
----@param platform? '"unix"'|'"windows"'
----@return string
-function M.path_to_os(path, platform)
-  platform = platform or (is_windows and "windows")
-  if platform == "windows" then
-    path, _ = path:gsub("/", "\\")
-    return path
-  else
-    path, _ = path:gsub("\\", "/")
-    return path
-  end
-end
-
----Check if a given path is absolute.
----@param path string
----@return boolean
-function M.path_is_abs(path)
-  if is_windows then
-    return path:match([[^%a:\]]) ~= nil
-  else
-    return path:sub(1, 1) == "/"
-  end
-end
-
----Joins an ordered list of path segments into a path string.
----@param paths string[]
----@return string
-function M.path_join(paths)
-  local result = paths[1]
-  for i = 2, #paths do
-    if tostring(paths[i]):sub(1, 1) == path_sep then
-      result = result .. paths[i]
-    else
-      result = result .. path_sep .. paths[i]
-    end
-  end
-  return result
-end
-
----Explodes the path into an ordered list of path segments.
----@param path string
----@return string[]
-function M.path_explode(path)
-  local parts = {}
-  for part in path:gmatch(string.format("([^%s]+)%s?", path_sep, path_sep)) do
-    table.insert(parts, part)
-  end
-  return parts
-end
-
----Get the basename of the given path.
----@param path string
----@return string
-function M.path_basename(path)
-  path = M.path_remove_trailing(path)
-  local i = path:match("^.*()" .. path_sep)
-  if not i then
-    return path
-  end
-  return path:sub(i + 1, #path)
-end
-
-function M.path_extension(path)
-  path = M.path_basename(path)
-  return path:match(".+%.(.*)")
-end
-
----Get the path to the parent directory of the given path. Returns `nil` if the
----path has no parent.
----@param path string
----@param remove_trailing boolean
----@return string|nil
-function M.path_parent(path, remove_trailing)
-  path = " " .. M.path_remove_trailing(path)
-  local i = path:match("^.+()" .. path_sep)
-  if not i then
-    return nil
-  end
-  path = path:sub(2, i)
-  if remove_trailing then
-    path = M.path_remove_trailing(path)
-  end
-  return path
-end
-
----Get a path relative to another path.
----@param path string
----@param relative_to string
----@return string
-function M.path_relative(path, relative_to)
-  local p, _ = path:gsub("^" .. M.pattern_esc(M.path_add_trailing(relative_to)), "")
-  return p
-end
-
-function M.path_add_trailing(path)
-  if path:sub(-1) == path_sep then
-    return path
-  end
-
-  return path .. path_sep
-end
-
-function M.path_remove_trailing(path)
-  local p, _ = path:gsub(path_sep .. "$", "")
-  return p
-end
-
-function M.path_shorten(path, max_length)
-  if string.len(path) > max_length - 1 then
-    path = path:sub(string.len(path) - max_length + 1, string.len(path))
-    local i = path:match("()" .. path_sep)
-    if not i then
-      return "…" .. path
-    end
-    return "…" .. path:sub(i, -1)
-  else
-    return path
-  end
 end
 
 function M.str_right_pad(s, min_size, fill)
@@ -575,7 +457,7 @@ function M.wipe_named_buffer(name)
 end
 
 function M.find_file_buffer(path)
-  local p = vim.fn.fnamemodify(path, ":p")
+  local p = M.path:absolute(path)
   for _, id in ipairs(vim.api.nvim_list_bufs()) do
     if p == vim.api.nvim_buf_get_name(id) then
       return id

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -191,7 +191,7 @@ function DiffView:update_files(callback)
     perf:lap("updated head rev")
   end
 
-  local index_stat = vim.loop.fs_stat(utils.path_join({ self.git_dir, "index" }))
+  local index_stat = utils.path:stat(utils.path:join(self.git_dir, "index"))
   local last_winid = api.nvim_get_current_win()
   self:get_updated_files(function(err, new_files)
     if err then

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -9,17 +9,15 @@ local api = vim.api
 local function prepare_goto_file(view)
   local file = view:infer_cur_file()
   if file then
-    if not file.right.type == RevType.LOCAL then
-      -- Ensure file exists
-      if vim.fn.filereadable(file.absolute_path) ~= 1 then
-        utils.err(
-          string.format(
-            "File does not exist on disk: '%s'",
-            vim.fn.fnamemodify(file.absolute_path, ":.")
-          )
+    -- Ensure file exists
+    if not utils.path:readable(file.absolute_path) then
+      utils.err(
+        string.format(
+          "File does not exist on disk: '%s'",
+          utils.path:relative(file.absolute_path, ".")
         )
-        return
-      end
+      )
+      return
     end
     return file
   end

--- a/lua/diffview/views/diff/render.lua
+++ b/lua/diffview/views/diff/render.lua
@@ -127,7 +127,7 @@ return function(panel)
   ---@type RenderComponent
   local comp = panel.components.path.comp
   local line_idx = 0
-  local s = utils.path_shorten(vim.fn.fnamemodify(panel.git_root, ":~"), panel.width - 6)
+  local s = utils.path:shorten(utils.path:vim_fnamemodify(panel.git_root, ":~"), panel.width - 6)
   comp:add_hl("DiffviewFilePanelRootPath", line_idx, 0, #s)
   comp:add_line(s)
 
@@ -172,11 +172,11 @@ return function(panel)
     comp = panel.components.info.entries.comp
     line_idx = 0
     for _, arg in ipairs(extra_info) do
-      local relpath = utils.path_relative(arg, panel.git_root)
+      local relpath = utils.path:relative(arg, panel.git_root)
       if relpath == "" then
         relpath = "."
       end
-      s = utils.path_shorten(relpath, panel.width - 5)
+      s = utils.path:shorten(relpath, panel.width - 5)
       comp:add_hl("DiffviewFilePanelPath", line_idx, 0, #s)
       comp:add_line(s)
       line_idx = line_idx + 1

--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -69,9 +69,9 @@ function FileEntry:init(opt)
   self.path = opt.path
   self.oldpath = opt.oldpath
   self.absolute_path = opt.absolute_path
-  self.parent_path = utils.path_parent(opt.path, true) or ""
-  self.basename = utils.path_basename(opt.path)
-  self.extension = utils.path_extension(opt.path)
+  self.parent_path = utils.path:parent(opt.path) or ""
+  self.basename = utils.path:basename(opt.path)
+  self.extension = utils.path:extension(opt.path)
   self.status = opt.status
   self.stats = opt.stats
   self.kind = opt.kind
@@ -171,7 +171,7 @@ function FileEntry:load_buffers(git_root, left_winid, right_winid, callback)
     perf:lap("null buffers loaded")
   end
 
-  utils.no_win_event_call(function()
+  local ok, err = utils.no_win_event_call(function()
     for _, split in ipairs(splits) do
       local on_ready = on_ready_factory(split)
 
@@ -225,6 +225,10 @@ function FileEntry:load_buffers(git_root, left_winid, right_winid, callback)
     end
   end)
 
+  if not ok then
+    utils.err(err)
+  end
+
   perf:lap("buffers attached")
 
   self.left_bufid = splits[1].bufid
@@ -273,7 +277,7 @@ function FileEntry:dispose_index_buffers()
 end
 
 function FileEntry:validate_index_buffers(git_root, git_dir, stat)
-  stat = stat or vim.loop.fs_stat(utils.path_join({ git_dir, "index" }))
+  stat = stat or utils.path:stat(utils.path:join(git_dir, "index"))
   local cached_stat
   if fstat_cache[git_root] then
     cached_stat = fstat_cache[git_root].index
@@ -321,7 +325,7 @@ end
 function FileEntry._get_null_buffer()
   if not (FileEntry._null_buffer and api.nvim_buf_is_loaded(FileEntry._null_buffer)) then
     local bn = api.nvim_create_buf(false, false)
-    local bufname = utils.path_join({ "diffview://", "null" })
+    local bufname = "diffview:///null"
     for option, value in pairs(FileEntry.bufopts) do
       api.nvim_buf_set_option(bn, option, value)
     end
@@ -360,10 +364,7 @@ function FileEntry._create_buffer(git_root, rev, path, null, callback)
   end
 
   -- stylua: ignore
-  local fullname = "diffview://" .. utils.path_to_os(
-    utils.path_join({ git_root, ".git", context, path }),
-    "unix"
-  )
+  local fullname = "diffview://" .. utils.path:join(git_root, ".git", context, path)
   for option, value in pairs(FileEntry.bufopts) do
     api.nvim_buf_set_option(bn, option, value)
   end
@@ -374,38 +375,32 @@ function FileEntry._create_buffer(git_root, rev, path, null, callback)
     local i = 1
     repeat
       -- stylua: ignore
-      fullname = "diffview://" .. utils.path_to_os(
-        utils.path_join({ git_root, ".git", context, i, path }),
-        "unix"
-      )
+      fullname = "diffview://" .. utils.path:join(git_root, ".git", context, i, path)
       ok = pcall(api.nvim_buf_set_name, bn, fullname)
       i = i + 1
     until ok
   end
 
   local git = require("diffview.git.utils")
-  git.show(
-    git_root, { (rev.commit or "") .. ":" .. utils.path_to_os(path, "unix") },
-    function(err, result)
-      if not err then
-        vim.schedule(function()
-          if api.nvim_buf_is_valid(bn) then
-            vim.bo[bn].modifiable = true
-            api.nvim_buf_set_lines(bn, 0, -1, false, result)
-            vim.bo[bn].modifiable = false
-            vim.api.nvim_buf_call(bn, function()
-              vim.cmd("filetype detect")
-            end)
-            callback()
-          end
-        end)
-      else
-        logger.error("[git] Failed to show file content.")
-        logger.error("[stderr] " .. table.concat(err, "\n"))
-        utils.err(string.format("Failed to create diff buffer: '%s'", fullname), true)
-      end
+  git.show(git_root, { (rev.commit or "") .. ":" .. path }, function(err, result)
+    if not err then
+      vim.schedule(function()
+        if api.nvim_buf_is_valid(bn) then
+          vim.bo[bn].modifiable = true
+          api.nvim_buf_set_lines(bn, 0, -1, false, result)
+          vim.bo[bn].modifiable = false
+          vim.api.nvim_buf_call(bn, function()
+            vim.cmd("filetype detect")
+          end)
+          callback()
+        end
+      end)
+    else
+      logger.error("[git] Failed to show file content.")
+      logger.error("[stderr] " .. table.concat(err, "\n"))
+      utils.err(string.format("Failed to create diff buffer: '%s'", fullname), true)
     end
-  )
+  end)
 
   return bn
 end
@@ -502,7 +497,7 @@ end
 
 ---@static
 function FileEntry.update_index_stat(git_root, git_dir, stat)
-  stat = stat or vim.loop.fs_stat(utils.path_join({ git_dir, "index" }))
+  stat = stat or utils.path:stat(utils.path:join(git_dir, "index"))
   if stat then
     if not fstat_cache[git_root] then
       fstat_cache[git_root] = {}

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -1,7 +1,6 @@
 local utils = require("diffview.utils")
 local git = require("diffview.git.utils")
 local lib = require("diffview.lib")
-local RevType = require("diffview.git.rev").RevType
 local DiffView = require("diffview.views.diff.diff_view").DiffView
 local FileEntry = require("diffview.views.file_entry").FileEntry
 local api = vim.api
@@ -9,17 +8,15 @@ local api = vim.api
 local function prepare_goto_file(view)
   local file = view:infer_cur_file()
   if file then
-    if not file.right.type == RevType.LOCAL then
-      -- Ensure file exists
-      if vim.fn.filereadable(file.absolute_path) ~= 1 then
-        utils.err(
-          string.format(
-            "File does not exist on disk: '%s'",
-            vim.fn.fnamemodify(file.absolute_path, ":.")
-          )
+    -- Ensure file exists
+    if not utils.path:readable(file.absolute_path) then
+      utils.err(
+        string.format(
+          "File does not exist on disk: '%s'",
+          utils.path:relative(file.absolute_path, ".")
         )
-        return
-      end
+      )
+      return
     end
     return file
   end
@@ -112,7 +109,6 @@ return function(view)
       if view.panel:is_cur_win() then
         local item = view.panel:get_item_at_cursor()
         if item then
-          -- print(vim.inspect(item))
           if item.files then
             if view.panel.single_file then
               view:set_file(item.files[1], false)
@@ -129,7 +125,6 @@ return function(view)
       if view.panel:is_cur_win() then
         local item = view.panel:get_item_at_cursor()
         if item then
-          -- print(vim.inspect(item))
           if item.files then
             if view.panel.single_file then
               view:set_file(item.files[1], true)

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -178,11 +178,11 @@ local function prepare_panel_cache(panel)
   local c = {}
   cache[panel] = c
   c.root_path = panel.form == Form.COLUMN
-      and utils.path_shorten(
-        vim.fn.fnamemodify(panel.git_root, ":~"),
+      and utils.path:shorten(
+        utils.path:vim_fnamemodify(panel.git_root, ":~"),
         panel.width - 6
       )
-    or vim.fn.fnamemodify(panel.git_root, ":~")
+    or utils.path:vim_fnamemodify(panel.git_root, ":~")
   c.args = table.concat(panel.raw_args, " ")
 end
 

--- a/lua/diffview/views/file_tree/file_tree.lua
+++ b/lua/diffview/views/file_tree/file_tree.lua
@@ -27,7 +27,7 @@ end
 
 ---@param file FileEntry
 function FileTree:add_file_entry(file)
-  local parts = utils.path_explode(file.path)
+  local parts = utils.path:explode(file.path)
   local cur_node = self.root
 
   -- Create missing intermediate pathname components
@@ -36,7 +36,7 @@ function FileTree:add_file_entry(file)
     local name = parts[i]
 
     if i > 1 then
-      path = utils.path_join({ path, parts[i] })
+      path = utils.path:join(path, parts[i])
     end
 
     if not cur_node.children[name] then
@@ -108,7 +108,7 @@ function FileTree:create_comp_schema(flatten_dirs)
         ---@type DirData
         local subdir_data = node.children[1].data
         dir_data = {
-          name = utils.path_join({ dir_data.name, subdir_data.name }),
+          name = utils.path:join(dir_data.name, subdir_data.name),
           path = subdir_data.path,
           kind = subdir_data.kind,
           collapsed = dir_data.collapsed and subdir_data.collapsed,


### PR DESCRIPTION
Fixes #101.

This let's us ensure UNIX paths everywhere which makes cross platform path handling a lot easier. Git does not handle windows style paths for things like i.e. pathspec. But nvim,  libuv  and git does support UNIX style paths even on windows.

Another benefit from avoiding the `vim.fn.*` functions for path handling is that the path lib can be used in libuv callbacks without scheduling.