### PR TITLE
feat: Specify any git rev as a base for file history.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Additional commands for convenience:
 With a Diffview open and the default key bindings, you can cycle through changed
 files with `<tab>` and `<s-tab>` (see configuration to change the key bindings).
 
-### `:DiffviewFileHistory [paths]`
+### `:DiffviewFileHistory [paths] [args]`
 
 Opens a new file history view that lists all commits that changed a given file
 or directory. If no `[paths]` are given, defaults to the current file. Multiple

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -155,7 +155,8 @@ default_args                                    *diffview-config-default_args*
 
         Examples: >
                 default_args = {
-                  DiffviewOpen = { "--untracked-files=no", "--imply-local" }
+                  DiffviewOpen = { "--untracked-files=no", "--imply-local" },
+                  DiffviewFileHistory = { "--base=LOCAL" },
                 }
 
 hooks                                                  *diffview-config-hooks*
@@ -255,7 +256,7 @@ COMMANDS                                                 *diffview-commands*
         :DiffviewOpen HEAD~2 -- lua/diffview plugin
         :DiffviewOpen d4a7b0d -uno
 <
-    Args:
+    Args:~
         -u[value], --untracked-files[={value}]
                         Specify whether or not to show untracked files. If
                         flag is given without value; defaults to `true`.
@@ -278,11 +279,13 @@ COMMANDS                                                 *diffview-commands*
                         current working directory.
 
                                                         *:DiffviewFileHistory*
-:DiffviewFileHistory [paths]
+:DiffviewFileHistory [paths] [args]
                         Opens a new file history view that lists all commits
                         that changed a given file or directory. If no [paths]
                         are given, defaults to the current file. Multiple
-                        [paths] may be provided.
+                        [paths] may be provided and git pathspec is supported
+                        (see `$ man gitglossary(7)` for information about
+                        pathspec).
 
                         From the file history panel (the panel listing the
                         commits) you can open an option panel by pressing
@@ -292,6 +295,25 @@ COMMANDS                                                 *diffview-commands*
                         followed by pressing <Tab>, or by using the mappings
                         that are shown directly in the panel, preceding the
                         flags' descriptions.
+
+                        Examples:
+>
+        :DiffviewFileHistory
+        :DiffviewFileHistory path/to/some/file.txt
+        :DiffviewFileHistory path/to/some/directory
+        :DiffviewFileHistory multiple/paths foo/bar baz/qux
+        :DiffviewFileHistory --base=HEAD~4
+        :DiffviewFileHistory --base=LOCAL
+<
+
+    Args:~
+        --base={git-rev}
+                        Specify a base git rev from which the right side of
+                        the diff will be created. Use the special value
+                        `LOCAL` to use the local version of the file.
+
+        -C{path}        Run as if git was started in {path} instead of the
+                        current working directory.
 
                                                         *:DiffviewClose*
 :DiffviewClose          Close the active Diffview.

--- a/lua/diffview.lua
+++ b/lua/diffview.lua
@@ -3,18 +3,30 @@ if not require("diffview.bootstrap") then
 end
 
 local arg_parser = require("diffview.arg_parser")
-local lib = require("diffview.lib")
-local config = require("diffview.config")
 local colors = require("diffview.colors")
+local config = require("diffview.config")
+local lib = require("diffview.lib")
 local utils = require("diffview.utils")
+
 local M = {}
 
 ---@type FlagValueMap
-local flag_value_completion = arg_parser.FlagValueMap()
-flag_value_completion:put({ "u", "untracked-files" }, { "true", "normal", "all", "false", "no" })
-flag_value_completion:put({ "cached", "staged" }, { "true", "false" })
-flag_value_completion:put({ "imply-local" }, { "true", "false" })
-flag_value_completion:put({ "C" }, {})
+local comp_open = arg_parser.FlagValueMap()
+comp_open:put({ "u", "untracked-files" }, { "true", "normal", "all", "false", "no" })
+comp_open:put({ "cached", "staged" }, { "true", "false" })
+comp_open:put({ "imply-local" }, { "true", "false" })
+comp_open:put({ "C" }, function(_, arg_lead)
+  return vim.fn.getcompletion(arg_lead, "dir")
+end)
+
+---@type FlagValueMap
+local comp_file_history = arg_parser.FlagValueMap()
+comp_file_history:put({ "base" }, function(_, arg_lead)
+  return M.filter_completion(arg_lead, M.rev_completion())
+end)
+comp_file_history:put({ "C" }, function(_, arg_lead)
+  return vim.fn.getcompletion(arg_lead, "dir")
+end)
 
 function M.setup(user_config)
   config.setup(user_config or {})
@@ -64,63 +76,117 @@ function M.close(tabpage)
   end
 end
 
-local function filter_completion(arg_lead, items)
+function M.filter_completion(arg_lead, items)
+  arg_lead, _ = vim.pesc(arg_lead)
   return vim.tbl_filter(function(item)
-    return item:match(utils.pattern_esc(arg_lead))
+    return item:match(arg_lead)
   end, items)
 end
 
 function M.completion(arg_lead, cmd_line, cur_pos)
   local args, argidx, divideridx = arg_parser.scan_ex_args(cmd_line, cur_pos)
-  local fpath = (
-      vim.bo.buftype == ""
-        and utils.path:readable(utils.path:vim_expand("%"))
-        and utils.path:vim_expand("%:p:h")
-      or "."
-    )
-  local git_dir = require("diffview.git.utils").git_dir(fpath)
-  local git_root = require("diffview.git.utils").toplevel(fpath)
-  local has_rev_arg = false
-
-  for i = 2, math.min(#args, divideridx) do
-    if args[i]:sub(1, 1) ~= "-" and i ~= argidx then
-      has_rev_arg = true
-      break
-    end
+  if M.completers[args[1]] then
+    return M.completers[args[1]](args, argidx, divideridx, arg_lead)
   end
-
-  if argidx >= divideridx then
-    return vim.fn.getcompletion(arg_lead, "file", 0)
-  elseif not has_rev_arg and arg_lead:sub(1, 1) ~= "-" and git_dir and git_root then
-    -- stylua: ignore start
-    local targets = {
-      "HEAD", "FETCH_HEAD", "ORIG_HEAD", "MERGE_HEAD",
-      "REBASE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD"
-    }
-    local heads = vim.tbl_filter(
-      function(name) return vim.tbl_contains(targets, name) end,
-      vim.tbl_map(
-        function(v) return utils.path:basename(v) end,
-        vim.fn.glob(git_dir .. "/*", false, true)
-      )
-    )
-    -- stylua: ignore end
-    local cmd = "git -C " .. vim.fn.shellescape(git_root) .. " "
-    local revs = vim.fn.systemlist(cmd .. "rev-parse --symbolic --branches --tags --remotes")
-    local stashes = vim.fn.systemlist(cmd .. "stash list --pretty=format:%gd")
-
-    return filter_completion(arg_lead, utils.vec_join(heads, revs, stashes))
-  else
-    local flag_completion = flag_value_completion:get_completion(arg_lead)
-    if flag_completion then
-      return filter_completion(arg_lead, flag_completion)
-    end
-
-    return filter_completion(arg_lead, flag_value_completion:get_all_names())
-  end
-
-  return args
 end
+
+function M.rev_completion(git_root, git_dir)
+  local cfile, fpath
+  if not (git_root and git_dir) then
+    cfile = utils.path:vim_expand("%")
+    fpath =
+        vim.bo.buftype == ""
+        and utils.path:readable(cfile)
+        and utils.path:parent(cfile)
+        or "."
+  end
+
+  git_root = git_root or require("diffview.git.utils").toplevel(fpath)
+  git_dir = git_dir or require("diffview.git.utils").git_dir(fpath)
+  if not (git_root and git_dir) then
+    return {}
+  end
+
+  -- stylua: ignore start
+  local targets = {
+    "HEAD", "FETCH_HEAD", "ORIG_HEAD", "MERGE_HEAD",
+    "REBASE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD"
+  }
+  local heads = vim.tbl_filter(
+    function(name) return vim.tbl_contains(targets, name) end,
+    vim.tbl_map(
+      function(v) return utils.path:basename(v) end,
+      vim.fn.glob(git_dir .. "/*", false, true)
+    )
+  )
+  -- stylua: ignore end
+  local revs = utils.system_list(
+    { "git", "rev-parse", "--symbolic", "--branches", "--tags", "--remotes" },
+    git_root,
+    true
+  )
+  local stashes = utils.system_list(
+    { "git", "stash", "list", "--pretty=format:%gd" },
+    git_root,
+    true
+  )
+
+  return utils.vec_join(heads, revs, stashes)
+end
+
+M.completers = {
+  DiffviewOpen = function(args, argidx, divideridx, arg_lead)
+    local cfile = utils.path:vim_expand("%")
+    local fpath =
+        vim.bo.buftype == ""
+        and utils.path:readable(cfile)
+        and utils.path:parent(cfile)
+        or "."
+    local git_dir = require("diffview.git.utils").git_dir(fpath)
+    local git_root = require("diffview.git.utils").toplevel(fpath)
+    local has_rev_arg = false
+
+    for i = 2, math.min(#args, divideridx) do
+      if args[i]:sub(1, 1) ~= "-" and i ~= argidx then
+        has_rev_arg = true
+        break
+      end
+    end
+
+    if argidx > divideridx then
+      return vim.fn.getcompletion(arg_lead, "file", 0)
+    elseif not has_rev_arg and arg_lead:sub(1, 1) ~= "-" and git_dir and git_root then
+      return M.filter_completion(arg_lead, M.rev_completion(git_root, git_dir))
+    else
+      local flag_completion = comp_open:get_completion(arg_lead)
+      if flag_completion then
+        return flag_completion
+      end
+
+      return M.filter_completion(arg_lead, comp_open:get_all_names())
+    end
+
+    return args
+  end,
+  ---@diagnostic disable-next-line: unused-local
+  DiffviewFileHistory = function(args, argidx, divideridx, arg_lead)
+    local candidates = {}
+
+    local flag_completion = comp_file_history:get_completion(arg_lead)
+    if flag_completion then
+      utils.vec_push(candidates, unpack(flag_completion))
+    else
+      utils.vec_push(
+        candidates,
+        unpack(M.filter_completion(arg_lead, comp_file_history:get_all_names()))
+      )
+    end
+
+    utils.vec_push(candidates, unpack(vim.fn.getcompletion(arg_lead, "file", 0)))
+
+    return candidates
+  end,
+}
 
 function M.update_colors()
   colors.setup()

--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -101,7 +101,7 @@ function PathLib:is_root(path)
   path = self:_clean(path)
   if self:is_abs(path) then
     if self._is_windows then
-      return path:match(("^([A-Z]:%s?$)"):format(vim.pesc(self.sep))) ~= nil
+      return path:match(("^([A-Z]:%s?$)"):format(self.sep)) ~= nil
     else
       return path == self.sep
     end

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -33,6 +33,7 @@ local perf_update = PerfTimer("[FileHistoryPanel] update")
 ---@field entries LogEntry[]
 ---@field path_args string[]
 ---@field raw_args string[]
+---@field base Rev
 ---@field log_options LogOptions
 ---@field cur_item {[1]: LogEntry, [2]: FileEntry}
 ---@field single_file boolean
@@ -70,8 +71,9 @@ FileHistoryPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 ---@param entries LogEntry[]
 ---@param path_args string[]
 ---@param log_options LogOptions
+---@param base Rev
 ---@return FileHistoryPanel
-function FileHistoryPanel:init(git_root, entries, path_args, raw_args, log_options)
+function FileHistoryPanel:init(git_root, entries, path_args, raw_args, log_options, base)
   local conf = config.get_config()
   FileHistoryPanel:super().init(self, {
     position = conf.file_history_panel.position,
@@ -83,6 +85,7 @@ function FileHistoryPanel:init(git_root, entries, path_args, raw_args, log_optio
   self.entries = entries
   self.path_args = path_args
   self.raw_args = raw_args
+  self.base = base
   self.cur_item = {}
   self.single_file = entries[1] and entries[1].single_file
   self.option_panel = FHOptionPanel(self)
@@ -241,6 +244,7 @@ function FileHistoryPanel:update_entries(callback)
     self.git_root,
     self.path_args,
     self.log_options,
+    self.base,
     update
   )
   self:update_components()

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -1,11 +1,12 @@
-local oop = require("diffview.oop")
-local git = require("diffview.git.utils")
 local Event = require("diffview.events").Event
 local EventEmitter = require("diffview.events").EventEmitter
-local StandardView = require("diffview.views.standard.standard_view").StandardView
-local LayoutMode = require("diffview.views.view").LayoutMode
 local FileEntry = require("diffview.views.file_entry").FileEntry
 local FileHistoryPanel = require("diffview.views.file_history.file_history_panel").FileHistoryPanel
+local LayoutMode = require("diffview.views.view").LayoutMode
+local StandardView = require("diffview.views.standard.standard_view").StandardView
+local git = require("diffview.git.utils")
+local oop = require("diffview.oop")
+
 local JobStatus = git.JobStatus
 local api = vim.api
 
@@ -35,7 +36,8 @@ function FileHistoryView:init(opt)
     {},
     self.path_args,
     self.raw_args,
-    opt.log_options
+    opt.log_options,
+    opt.base
   )
 end
 

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -3,7 +3,6 @@ local config = require("diffview.config")
 local renderer = require("diffview.renderer")
 local logger = require("diffview.logger")
 local Form = require("diffview.ui.panel").Form
-local RevType = require("diffview.git.rev").RevType
 local PerfTimer = require("diffview.perf").PerfTimer
 
 ---@type PerfTimer
@@ -142,10 +141,7 @@ local function render_entries(parent, entries, updating)
     end
 
     offset = #s + 1
-    local subject = #entry.files > 0
-        and entry.files[1].right.type == RevType.LOCAL
-        and "[Not Committed Yet]"
-      or utils.str_shorten(entry.commit.subject, 72)
+    local subject = utils.str_shorten(entry.commit.subject, 72)
     comp:add_hl("DiffviewFilePanelFileName", line_idx, offset, offset + #subject)
     s = s .. " " .. subject
 

--- a/plugin/diffview.vim
+++ b/plugin/diffview.vim
@@ -5,7 +5,7 @@ if !luaeval("require('diffview.bootstrap')")
 endif
 
 command! -complete=customlist,s:completion -nargs=* DiffviewOpen lua require'diffview'.open(<f-args>)
-command! -complete=file -nargs=* DiffviewFileHistory lua require'diffview'.file_history(<f-args>)
+command! -complete=customlist,s:completion -nargs=* DiffviewFileHistory lua require'diffview'.file_history(<f-args>)
 command! -bar -nargs=0 DiffviewClose lua require'diffview'.close()
 command! -bar -nargs=0 DiffviewFocusFiles lua require'diffview'.trigger_event("focus_files")
 command! -bar -nargs=0 DiffviewToggleFiles lua require'diffview'.trigger_event("toggle_files")


### PR DESCRIPTION
Resolves #95.

You can now specify the base rev for the `:DiffviewFileHistory` command by using
the `--base` flag. This will keep the state of the file on the right side of the
diff split constant as you go through commits in the history.

```vimhelp
    --base={git-rev}
                    Specify a base git rev from which the right side of
                    the diff will be created. Use the special value
                    `LOCAL` to use the local version of the file.
```

### Examples:

- `:DiffviewFileHistory --base=HEAD~4`
- `:DiffviewFileHistory --base=LOCAL`

### Other changes:

- (feat) Better completion for individual flags. I.e. the 'C' flag now provides
  directory completion.
- (feat) File history now supports the 'C' flag.
- (fix) Detection of single-file file history.