### PR TITLE
Configurable file panel summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ require'diffview'.setup {
     width = 35,                         -- Only applies when position is 'left' or 'right'
     height = 10,                        -- Only applies when position is 'top' or 'bottom'
     listing_style = "tree",             -- One of 'list' or 'tree'
+    render_summary = true,              -- Render changes summary at the top
     tree_options = {                    -- Only applies when listing_style is 'tree'
       flatten_dirs = true,              -- Flatten dirs that only contain one single dir
       folder_statuses = "only_folded",  -- One of 'never', 'only_folded' or 'always'.

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -53,6 +53,7 @@ Example configuration with default settings:
         width = 35,                         -- Only applies when position is 'left' or 'right'
         height = 10,                        -- Only applies when position is 'top' or 'bottom'
         listing_style = "tree",             -- One of 'list' or 'tree'
+        render_summary = true,              -- Render changes summary at the top
         tree_options = {                    -- Only applies when listing_style is 'tree'
           flatten_dirs = true,              -- Flatten dirs that only contain one single dir
           folder_statuses = "only_folded",  -- One of 'never', 'only_folded' or 'always'.

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -26,6 +26,7 @@ M.defaults = {
     width = 35,                   -- Only applies when position is 'left' or 'right'
     height = 10,                  -- Only applies when position is 'top' or 'bottom'
     listing_style = "tree",       -- One of 'list' or 'tree'
+    render_summary = true,        -- Render changes summary at the top
     tree_options = {              -- Only applies when listing_style is 'tree'
       flatten_dirs = true,
       folder_statuses = "only_folded"  -- One of 'never', 'only_folded' or 'always'.

--- a/lua/diffview/views/diff/render.lua
+++ b/lua/diffview/views/diff/render.lua
@@ -122,6 +122,7 @@ return function(panel)
     return
   end
 
+  local conf = config.get_config()
   panel.render_data:clear()
 
   ---@type RenderComponent
@@ -133,12 +134,15 @@ return function(panel)
 
   comp = panel.components.working.title.comp
   line_idx = 0
-  s = "Changes"
-  comp:add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
-  local change_count = "(" .. #panel.files.working .. ")"
-  comp:add_hl("DiffviewFilePanelCounter", line_idx, #s + 1, #s + 1 + string.len(change_count))
-  s = s .. " " .. change_count
-  comp:add_line(s)
+
+  if conf.file_panel.render_summary then
+    s = "Changes"
+    comp:add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
+    local change_count = "(" .. #panel.files.working .. ")"
+    comp:add_hl("DiffviewFilePanelCounter", line_idx, #s + 1, #s + 1 + string.len(change_count))
+    s = s .. " " .. change_count
+    comp:add_line(s)
+  end
 
   render_files(panel.listing_style, panel.components.working.files.comp)
 


### PR DESCRIPTION
Add `file_panel.render_summary` boolean option (defaults to `true`) to control if changes summary should be rendered at the top of the file panel.

This makes one less line in the file panel which is really useful for small screens.

Thanks for the plugin!
