### PR TITLE
fix: Explicitly set foldenable for the diff view

### DIFF
--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -53,6 +53,7 @@ FileEntry.winopts = {
   foldmethod = "diff",
   foldcolumn = "1",
   foldlevel = 0,
+  foldenable = true,
 }
 
 FileEntry.bufopts = {


### PR DESCRIPTION
Users may have `set nofoldenable` option in their vimrc, in which case
the diff view windows will not have fold when opening. The `foldenable`
option therefore needs to be explicitly set.
