### PR TITLE
BREAKING CHANGE: Commit log panel and new config for panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,17 @@ require'diffview'.setup {
     fold_open = "",
   },
   file_panel = {
-    position = "left",                  -- One of 'left', 'right', 'top', 'bottom'
-    width = 35,                         -- Only applies when position is 'left' or 'right'
-    height = 10,                        -- Only applies when position is 'top' or 'bottom'
     listing_style = "tree",             -- One of 'list' or 'tree'
     tree_options = {                    -- Only applies when listing_style is 'tree'
       flatten_dirs = true,              -- Flatten dirs that only contain one single dir
       folder_statuses = "only_folded",  -- One of 'never', 'only_folded' or 'always'.
     },
+    win_config = {                      -- See ':h diffview-config-win_config'
+      position = "left",
+      width = 35,
+    },
   },
   file_history_panel = {
-    position = "bottom",
-    width = 35,
-    height = 16,
     log_options = {
       max_count = 256,      -- Limit the number of commits
       follow = false,       -- Follow renames (only for single file)
@@ -79,6 +77,13 @@ require'diffview'.setup {
       no_merges = false,    -- List no merge commits
       reverse = false,      -- List commits in reverse order
     },
+    win_config = {          -- See ':h diffview-config-win_config'
+      position = "bottom",
+      height = 16,
+    },
+  },
+  commit_log_panel = {
+    win_config = {},  -- See ':h diffview-config-win_config'
   },
   default_args = {    -- Default args prepended to the arg-list for the listed commands
     DiffviewOpen = {},
@@ -111,6 +116,7 @@ require'diffview'.setup {
       ["U"]             = cb("unstage_all"),          -- Unstage all entries.
       ["X"]             = cb("restore_entry"),        -- Restore entry to the state on the left side.
       ["R"]             = cb("refresh_files"),        -- Update stats and entries in the file list.
+      ["L"]             = cb("open_commit_log"),      -- Open the commit log panel.
       ["<tab>"]         = cb("select_next_entry"),
       ["<s-tab>"]       = cb("select_prev_entry"),
       ["gf"]            = cb("goto_file"),
@@ -125,6 +131,7 @@ require'diffview'.setup {
       ["g!"]            = cb("options"),            -- Open the option panel
       ["<C-A-d>"]       = cb("open_in_diffview"),   -- Open the entry under the cursor in a diffview
       ["y"]             = cb("copy_hash"),          -- Copy the commit hash of the entry under the cursor
+      ["L"]             = cb("open_commit_log"),
       ["zR"]            = cb("open_all_folds"),
       ["zM"]            = cb("close_all_folds"),
       ["j"]             = cb("next_entry"),

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ use { 'sindrets/diffview.nvim', requires = 'nvim-lua/plenary.nvim' }
 
 ## Configuration
 
+<p>
+<details>
+<summary style='cursor: pointer'><b>Example config with default values</b></summary>
+
 ```lua
 -- Lua
 local cb = require'diffview.config'.diffview_callback
@@ -145,6 +149,9 @@ require'diffview'.setup {
   },
 }
 ```
+
+</details>
+</p>
 
 The diff windows can be aligned either with a horizontal split or a vertical
 split. To change the alignment add either `horizontal` or `vertical` to your

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -49,24 +49,17 @@ Example configuration with default settings:
         fold_open = "",
       },
       file_panel = {
-        position = "left",                  -- One of 'left', 'right', 'top', 'bottom'
-        width = 35,                         -- Only applies when position is 'left' or 'right'
-        height = 10,                        -- Only applies when position is 'top' or 'bottom'
         listing_style = "tree",             -- One of 'list' or 'tree'
         tree_options = {                    -- Only applies when listing_style is 'tree'
           flatten_dirs = true,              -- Flatten dirs that only contain one single dir
           folder_statuses = "only_folded",  -- One of 'never', 'only_folded' or 'always'.
         },
+        win_config = {                      -- See |diffview-config-win_config|
+          position = "left",
+          width = 35,
+        },
       },
-      default_args = {    -- Default args prepended to the arg-list for the listed commands
-        DiffviewOpen = {},
-        DiffviewFileHistory = {},
-      },
-      hooks = {},         -- See |diffview-config-hooks|
       file_history_panel = {
-        position = "bottom",
-        width = 35,
-        height = 16,
         log_options = {
           max_count = 256,      -- Limit the number of commits
           follow = false,       -- Follow renames (only for single file)
@@ -75,7 +68,19 @@ Example configuration with default settings:
           no_merges = false,    -- List no merge commits
           reverse = false,      -- List commits in reverse order
         },
+        win_config = {          -- See |diffview-config-win_config|
+          position = "bottom",
+          height = 16,
+        },
       },
+      commit_log_panel = {
+        win_config = {},  -- See |diffview-config-win_config|
+      },
+      default_args = {    -- Default args prepended to the arg-list for the listed commands
+        DiffviewOpen = {},
+        DiffviewFileHistory = {},
+      },
+      hooks = {},         -- See |diffview-config-hooks|
       key_bindings = {
         disable_defaults = false,                   -- Disable the default key bindings
         -- The `view` bindings are active in the diff buffers, only when the current
@@ -102,6 +107,7 @@ Example configuration with default settings:
           ["U"]             = cb("unstage_all"),          -- Unstage all entries.
           ["X"]             = cb("restore_entry"),        -- Restore entry to the state on the left side.
           ["R"]             = cb("refresh_files"),        -- Update stats and entries in the file list.
+          ["L"]             = cb("open_commit_log"),      -- Open the commit log panel.
           ["<tab>"]         = cb("select_next_entry"),
           ["<s-tab>"]       = cb("select_prev_entry"),
           ["gf"]            = cb("goto_file"),
@@ -116,6 +122,7 @@ Example configuration with default settings:
           ["g!"]            = cb("options"),            -- Open the option panel
           ["<C-A-d>"]       = cb("open_in_diffview"),   -- Open the entry under the cursor in a diffview
           ["y"]             = cb("copy_hash"),          -- Copy the commit hash of the entry under the cursor
+          ["L"]             = cb("open_commit_log"),
           ["zR"]            = cb("open_all_folds"),
           ["zM"]            = cb("close_all_folds"),
           ["j"]             = cb("next_entry"),
@@ -148,7 +155,91 @@ enhanced_diff_hl                                *diffview-config-enhanced_diff_h
         in the left diff buffer will be highlighted as |hl-DiffDelete|, and
         the delete fill-chars will be highlighted more subtly.
 
+win_config                                      *diffview-config-win_config*
+        Type: `table | fun(): table`, Default: `{}`
+
+        This is used to configure the windows of the various panels in the
+        plugin. If this is set to a function, it should return the config
+        table when called (usually whenever the panel opens). If
+        `type="float"`, then this should be the config table passed to
+        |nvim_open_win()|.
+
+        Certain fields are only applicable for either `type="split"` or
+        `type="float"`. If a field description is designated as "when
+        `type="split"`", then this implies that the field has a different
+        function when `type="float"`. When that is the case, the field's float
+        behavior is documented under |nvim_open_win()|.
+
+        Fields: ~
+            {type} ("split"|"float")
+                Determines whether the window should be a float or a normal
+                split.
+
+            {width} (integer)
+                The width of the window (in character cells). If `type` is
+                `"split"` then this is only applicable when `position` is
+                `"left"|"right"`.
+
+            {height} (integer)
+                The width of the window (in character cells). If `type` is
+                `"split"` then this is only applicable when `position` is
+                `"top"|"bottom"`.
+
+            {position} ("left"|"top"|"right"|"bottom")
+                Determines where the panel is positioned (only when
+                `type="split"`).
+
+            {relative} ("editor"|"win")
+                Determines what the `position` is relative to (when
+                `type="split"`).
+                Default: `"editor"`
+
+            {win} (integer)
+                The window handle of the target relative window (when
+                `type="split"`. Only when `relative="win"`). Use `0` for
+                current window.
+                Default: `0`
+
+            NOTE: Fields that are only applicable when `type="float"` are not
+            listed here because they are already documented under
+            |nvim_open_win|.
+
+        Examples: >
+                -- Split window, aligned to the right side of the editor:
+                win_config = {
+                  type = "split",
+                  position = "right",
+                  width = 40,
+                }
+
+                -- Split window, aligned to the bottom of the first window in
+                -- the current tabpage:
+                win_config = function()
+                  local c = {
+                    type = "split",
+                    position = "bottom",
+                    relative = "win",
+                    height = 14,
+                  }
+                  c.win = vim.api.nvim_tabpage_list_wins(0)[1]
+                  return c
+                end
+
+                -- Floating window, centered in the editor:
+                win_config = function()
+                  local c = { type = "float" }
+                  local editor_width = vim.o.columns
+                  local editor_height = vim.o.lines
+                  c.width = math.min(100, editor_width)
+                  c.height = math.min(24, editor_height)
+                  c.col = math.floor(editor_width * 0.5 - c.width * 0.5)
+                  c.row = math.floor(editor_height * 0.5 - c.height * 0.5)
+                  return c
+                end,
+
 default_args                                    *diffview-config-default_args*
+        Type: `table<string, string[]>`, Default: `{}`
+
         This table allows you to define the default args that will always be
         prepended to the arg-list for the commands specified by the table
         keys.

--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -1,9 +1,57 @@
 ================================================================================
-                                                          *diffview.changelog*
+                                                *diffview.changelog*
 
 CHANGELOG
 
-                                                       *diffview.changelog-93*
+                                                *diffview.changelog-136*
+
+PR: https://github.com/sindrets/diffview.nvim/pull/136
+
+This PR refactors the internal representation of a panel (the various
+interactive windows used in the plugin). The way panels are configured has
+been changed and extended in a manner that is incompatible with the way it was
+done before. To update your config, just move all the window related options
+into a new table key `win_config`:
+
+        Before: ~
+>
+                require("diffview").setup({
+                  -- other options...
+                  file_panel = {
+                    position = "left",
+                    width = 35,
+                    height = 16,
+                    listing_style = "tree",
+                    tree_options = {
+                      flatten_dirs = true,
+                      folder_statuses = "only_folded",
+                    },
+                  },
+                })
+<
+        After: ~
+>
+                require("diffview").setup({
+                  -- other options...
+                  file_panel = {
+                    win_config = {
+                      position = "left",
+                      width = 35,
+                      height = 16,
+                    },
+                    listing_style = "tree",
+                    tree_options = {
+                      flatten_dirs = true,
+                      folder_statuses = "only_folded",
+                    },
+                  },
+                })
+<
+This goes for both the `file_panel` and the `file_history_panel` config. To
+see all the available options for `win_config`, see
+|diffview-config-win_config|.
+
+                                                *diffview.changelog-93*
 
 PR: https://github.com/sindrets/diffview.nvim/pull/93
 
@@ -20,7 +68,7 @@ update, just make sure plenary is loaded before diffview. Examples:
             `Plug 'nvim-lua/plenary.nvim'`
             `Plug 'sindrets/diffview.nvim'`
 
-                                                       *diffview.changelog-64*
+                                                *diffview.changelog-64*
 
 PR: https://github.com/sindrets/diffview.nvim/pull/64
 

--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -16,34 +16,26 @@ into a new table key `win_config`:
         Before: ~
 >
                 require("diffview").setup({
-                  -- other options...
+                  -- ...
                   file_panel = {
                     position = "left",
                     width = 35,
                     height = 16,
-                    listing_style = "tree",
-                    tree_options = {
-                      flatten_dirs = true,
-                      folder_statuses = "only_folded",
-                    },
+                    -- (Other options...)
                   },
                 })
 <
         After: ~
 >
                 require("diffview").setup({
-                  -- other options...
+                  -- ...
                   file_panel = {
                     win_config = {
                       position = "left",
                       width = 35,
                       height = 16,
                     },
-                    listing_style = "tree",
-                    tree_options = {
-                      flatten_dirs = true,
-                      folder_statuses = "only_folded",
-                    },
+                    -- (Other options...)
                   },
                 })
 <

--- a/lua/diffview/api/views/file_entry.lua
+++ b/lua/diffview/api/views/file_entry.lua
@@ -57,20 +57,30 @@ function CFileEntry:load_buffers(git_root, left_winid, right_winid, callback)
       split.ready = true
       local was_ready = self[split.pos .. "_ready"]
       self[split.pos .. "_ready"] = true
+
       if splits[1].ready and splits[2].ready then
+
+        -- Load and set the buffer
         for _, sp in ipairs(splits) do
           if sp.load then
             sp.load()
           else
             api.nvim_win_set_buf(sp.winid, sp.bufid)
           end
-          if not was_ready then
-            api.nvim_win_call(sp.winid, function()
-              DiffviewGlobal.emitter:emit("diff_buf_read", sp.bufid)
-            end)
-          end
         end
+
         CFileEntry._update_windows(left_winid, right_winid)
+
+        -- Call hooks
+        for _, sp in ipairs(splits) do
+          api.nvim_win_call(sp.winid, function()
+            if not was_ready then
+              DiffviewGlobal.emitter:emit("diff_buf_read", sp.bufid)
+            end
+            DiffviewGlobal.emitter:emit("diff_buf_win_enter", sp.bufid)
+          end)
+        end
+
         if type(callback) == "function" then
           callback()
         end
@@ -172,7 +182,7 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
 
   local context
   if rev.type == RevType.COMMIT then
-    context = rev:abbrev()
+    context = rev:abbrev(11)
   elseif rev.type == RevType.INDEX then
     context = ":0:"
   elseif rev.type == RevType.CUSTOM then
@@ -211,7 +221,7 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
         callback()
       end
     end)
-  end)
+  end, nil)
 
   return bn
 end

--- a/lua/diffview/api/views/file_entry.lua
+++ b/lua/diffview/api/views/file_entry.lua
@@ -190,7 +190,7 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
   end
 
   -- stylua: ignore
-  local fullname = "diffview://" .. utils.path:join(git_root, ".git", context, path)
+  local fullname = utils.path:join("diffview://", git_root, ".git", context, path)
   for option, value in pairs(FileEntry.bufopts) do
     api.nvim_buf_set_option(bn, option, value)
   end
@@ -201,7 +201,7 @@ function CFileEntry._create_buffer(git_root, rev, path, producer, null, callback
     local i = 1
     while not ok do
       -- stylua: ignore
-      fullname = "diffview://" .. utils.path:join(git_root, ".git", context, i, path)
+      fullname = utils.path:join("diffview://", git_root, ".git", context, i, path)
       ok = pcall(api.nvim_buf_set_name, bn, fullname)
       i = i + 1
     end

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -22,19 +22,17 @@ M.defaults = {
     fold_open = "",
   },
   file_panel = {
-    position = "left",            -- One of 'left', 'right', 'top', 'bottom'
-    width = 35,                   -- Only applies when position is 'left' or 'right'
-    height = 10,                  -- Only applies when position is 'top' or 'bottom'
     listing_style = "tree",       -- One of 'list' or 'tree'
     tree_options = {              -- Only applies when listing_style is 'tree'
       flatten_dirs = true,
       folder_statuses = "only_folded"  -- One of 'never', 'only_folded' or 'always'.
-    }
+    },
+    win_config = {
+      position = "left",
+      width = 35,
+    },
   },
   file_history_panel = {
-    position = "bottom",
-    width = 35,
-    height = 16,
     log_options = {
       max_count = 256,
       follow = false,
@@ -42,10 +40,13 @@ M.defaults = {
       merges = false,
       no_merges = false,
       reverse = false,
-    }
+    },
+    win_config = {
+      position = "bottom",
+      height = 16,
+    },
   },
   commit_log_panel = {
-    type = "float",
     win_config = {},
   },
   default_args = {
@@ -77,7 +78,7 @@ M.defaults = {
       ["U"]             = cb("unstage_all"),
       ["X"]             = cb("restore_entry"),
       ["R"]             = cb("refresh_files"),
-      ["L"]             = cb("open_log"),
+      ["L"]             = cb("open_commit_log"),
       ["<tab>"]         = cb("select_next_entry"),
       ["<s-tab>"]       = cb("select_prev_entry"),
       ["gf"]            = cb("goto_file"),
@@ -92,7 +93,7 @@ M.defaults = {
       ["g!"]            = cb("options"),
       ["<C-A-d>"]       = cb("open_in_diffview"),
       ["y"]             = cb("copy_hash"),
-      ["L"]             = cb("open_log"),
+      ["L"]             = cb("open_commit_log"),
       ["zR"]            = cb("open_all_folds"),
       ["zM"]            = cb("close_all_folds"),
       ["j"]             = cb("next_entry"),
@@ -134,10 +135,33 @@ function M.setup(user_config)
   ---@type EventEmitter
   M.user_emitter = EventEmitter()
 
-  -- deprecation notices
+  --#region DEPRECATION NOTICES
+
   if type(M._config.file_panel.use_icons) ~= "nil" then
     utils.warn("'file_panel.use_icons' has been deprecated. See ':h diffview.changelog-64'.")
   end
+
+  local old_win_config_spec = { "position", "width", "height" }
+  for _, panel_name in ipairs({ "file_panel", "file_history_panel" }) do
+    local panel_config = M._config[panel_name]
+    local notified = false
+
+    for _, option in ipairs(old_win_config_spec) do
+      if panel_config[option] ~= nil then
+        if not notified then
+          utils.warn(
+            ("'%s.{position|width|height}' has been deprecated. See ':h diffview.changelog-136'.")
+            :format(panel_name)
+          )
+          notified = true
+        end
+        panel_config.win_config[option] = panel_config[option]
+        panel_config[option] = nil
+      end
+    end
+  end
+
+  --#endregion
 
   for event, callback in pairs(M._config.hooks) do
     if type(callback) == "function" then

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -44,6 +44,10 @@ M.defaults = {
       reverse = false,
     }
   },
+  commit_log_panel = {
+    type = "float",
+    win_config = {},
+  },
   default_args = {
     DiffviewOpen = {},
     DiffviewFileHistory = {},
@@ -73,6 +77,7 @@ M.defaults = {
       ["U"]             = cb("unstage_all"),
       ["X"]             = cb("restore_entry"),
       ["R"]             = cb("refresh_files"),
+      ["L"]             = cb("open_log"),
       ["<tab>"]         = cb("select_next_entry"),
       ["<s-tab>"]       = cb("select_prev_entry"),
       ["gf"]            = cb("goto_file"),
@@ -87,6 +92,7 @@ M.defaults = {
       ["g!"]            = cb("options"),
       ["<C-A-d>"]       = cb("open_in_diffview"),
       ["y"]             = cb("copy_hash"),
+      ["L"]             = cb("open_log"),
       ["zR"]            = cb("open_all_folds"),
       ["zM"]            = cb("close_all_folds"),
       ["j"]             = cb("next_entry"),

--- a/lua/diffview/events.lua
+++ b/lua/diffview/events.lua
@@ -11,16 +11,23 @@ local Event = oop.enum({
   "FILES_STAGED",
 })
 
+---@alias ListenerType '"normal"'|'"once"'|'"any"'|'"any_once"'
+
+---@class Listener
+---@field type ListenerType
+---@field callback function The original callback
+---@field call function
+
 ---@class EventEmitter : Object
----@field listeners table<Event, function[]>
----@field any_listeners function[]
+---@field event_map table<Event, Listener[]> # Registered events mapped to subscribed listeners.
+---@field any_listeners Listener[] # Listeners subscribed to all events.
 ---@field emit_lock table<Event, boolean>
 local EventEmitter = oop.create_class("EventEmitter")
 
 ---EventEmitter constructor.
 ---@return EventEmitter
 function EventEmitter:init()
-  self.listeners = {}
+  self.event_map = {}
   self.any_listeners = {}
   self.emit_lock = {}
 end
@@ -29,48 +36,106 @@ end
 ---@param event any Event identifier.
 ---@param callback function
 function EventEmitter:on(event, callback)
-  if not self.listeners[event] then
-    self.listeners[event] = {}
+  if not self.event_map[event] then
+    self.event_map[event] = {}
   end
-  table.insert(self.listeners[event], function(args)
-    callback(utils.tbl_unpack(args))
-  end)
+  table.insert(self.event_map[event], {
+    type = "normal",
+    callback = callback,
+    call = function(args)
+      callback(utils.tbl_unpack(args))
+    end,
+  })
 end
 
 ---Subscribe a one-shot listener to a given event.
 ---@param event any Event identifier.
 ---@param callback function
 function EventEmitter:once(event, callback)
-  if not self.listeners[event] then
-    self.listeners[event] = {}
+  if not self.event_map[event] then
+    self.event_map[event] = {}
   end
   local emitted = false
-  table.insert(self.listeners[event], function(args)
-    if not emitted then
-      emitted = true
-      callback(utils.tbl_unpack(args))
-    end
-  end)
+  table.insert(self.event_map[event], {
+    type = "once",
+    callback = callback,
+    call = function(args)
+      if not emitted then
+        emitted = true
+        self:off(callback, event)
+        callback(utils.tbl_unpack(args))
+      end
+    end,
+  })
 end
 
 ---Add a new any-listener, subscribed to all events.
 ---@param callback function
 function EventEmitter:on_any(callback)
-  table.insert(self.any_listeners, function(event, args)
-    callback(event, args)
-  end)
+  table.insert(self.any_listeners, {
+    type = "any",
+    callback = callback,
+    call = function(event, args)
+      callback(event, args)
+    end,
+  })
 end
 
 ---Add a new one-shot any-listener, subscribed to all events.
 ---@param callback function
 function EventEmitter:once_any(callback)
   local emitted = false
-  table.insert(self.any_listeners, function(event, args)
-    if not emitted then
-      emitted = true
-      callback(event, utils.tbl_unpack(args))
+  table.insert(self.any_listeners, {
+    type = "any_once",
+    callback = callback,
+    call = function(event, args)
+      if not emitted then
+        emitted = true
+        callback(event, utils.tbl_unpack(args))
+      end
+    end,
+  })
+end
+
+---Unsubscribe a listener. If no event is given, the listener is unsubscribed
+---from all events.
+---@param callback function
+---@param event? any Only unsubscribe listeners from this event.
+function EventEmitter:off(callback, event)
+  ---@type Listener[][]
+  local all
+  if event then
+    all = { self.event_map[event] }
+  else
+    all = utils.vec_join(
+      vim.tbl_values(self.event_map),
+      { self.any_listeners }
+    )
+  end
+
+  for _, listeners in ipairs(all) do
+    local remove = {}
+
+    for i, listener in ipairs(listeners) do
+      if listener.callback == callback then
+        remove[#remove + 1] = i
+      end
     end
-  end)
+
+    for i = #remove, 1, -1 do
+      table.remove(listeners, remove[i])
+    end
+  end
+end
+
+---Clear all listeners for a given event. If no event is given: clear all listeners.
+---@param event any?
+function EventEmitter:clear(event)
+  for e, _ in pairs(self.event_map) do
+    if event == nil or event == e then
+      self.event_map[e] = nil
+    end
+  end
 end
 
 ---Notify all listeners subscribed a given event.
@@ -79,13 +144,13 @@ end
 function EventEmitter:emit(event, ...)
   if not self.emit_lock[event] then
     local args = utils.tbl_pack(...)
-    if type(self.listeners[event]) == "table" then
-      for _, cb in ipairs(self.listeners[event]) do
-        cb(args)
+    if type(self.event_map[event]) == "table" then
+      for _, listener in ipairs(self.event_map[event]) do
+        listener.call(args)
       end
     end
-    for _, cb in ipairs(self.any_listeners) do
-      cb(event, args)
+    for _, listener in ipairs(self.any_listeners) do
+      listener.call(event, args)
     end
   end
 end
@@ -98,18 +163,25 @@ function EventEmitter:nore_emit(event, ...)
     self.emit_lock[event] = true
     local args = utils.tbl_pack(...)
 
-    if type(self.listeners[event]) == "table" then
-      for _, cb in ipairs(self.listeners[event]) do
-        cb(args)
+    if type(self.event_map[event]) == "table" then
+      for _, listener in ipairs(self.event_map[event]) do
+        listener.call(args)
       end
     end
 
-    for _, cb in ipairs(self.any_listeners) do
-      cb(event, args)
+    for _, listener in ipairs(self.any_listeners) do
+      listener.call(event, args)
     end
 
     self.emit_lock[event] = false
   end
+end
+
+---Get all listeners subscribed to the given event.
+---@param event any Event identifier.
+---@return Listener[]?
+function EventEmitter:get(event)
+  return self.event_map[event]
 end
 
 M.Event = Event

--- a/lua/diffview/git/file_dict.lua
+++ b/lua/diffview/git/file_dict.lua
@@ -1,8 +1,8 @@
 local oop = require("diffview.oop")
-local FileTree = require("diffview.views.file_tree.file_tree").FileTree
+local FileTree = require("diffview.ui.models.file_tree.file_tree").FileTree
 local M = {}
 
----@type table<integer, FileEntry>
+---@type { [integer]: FileEntry }
 ---@class FileDict : Object
 ---@field working FileEntry[]
 ---@field staged FileEntry[]

--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -779,7 +779,7 @@ end
 ---@param right Rev
 ---@return string|nil
 function M.rev_to_pretty_string(left, right)
-  if left.head and right.type == RevType.LOCAL then
+  if left.track_head and right.type == RevType.LOCAL then
     return nil
   elseif left.commit and right.type == RevType.LOCAL then
     return left:abbrev()

--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -738,6 +738,21 @@ function M.file_history_dry_run(git_root, path_args, log_opt, opt)
   return code == 0 and #out > 0, table.concat(description, ", ")
 end
 
+---Determine whether a rev arg is a range.
+---@param rev_arg string
+---@return boolean
+function M.is_rev_arg_range(rev_arg)
+  return utils.str_match(rev_arg, {
+    "^%.%.%.?$",
+    "^%.%.%.?[^.]",
+    "[^.]%.%.%.?$",
+    "[^.]%.%.%.?[^.]",
+    "^.-%^@",
+    "^.-%^!",
+    "^.-%^%-%d?",
+  }) ~= nil
+end
+
 ---Convert revs to git rev args.
 ---@param left Rev
 ---@param right Rev

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -248,11 +248,18 @@ function M.parse_revs(git_root, rev_arg, opt)
       return
     end
 
-    if #rev_strings > 1 then
-      local left_hash = rev_strings[2]:gsub("^%^", "")
+    local is_range = git.is_rev_arg_range(rev_arg)
+
+    if is_range then
       local right_hash = rev_strings[1]:gsub("^%^", "")
-      left = Rev(RevType.COMMIT, left_hash)
       right = Rev(RevType.COMMIT, right_hash)
+      if #rev_strings > 1 then
+        local left_hash = rev_strings[2]:gsub("^%^", "")
+        left = Rev(RevType.COMMIT, left_hash)
+      else
+        left = Rev.new_null_tree()
+      end
+
       if opt.imply_local then
         left, right = M.imply_local(left, right, head)
       end

--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -318,7 +318,7 @@ function PathLib:relative(path, relative_to, no_resolve)
   return p
 end
 
----Shotren a path by truncating the head.
+---Shorten a path by truncating the head.
 ---@param path string
 ---@param max_length integer
 ---@return string

--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -45,6 +45,13 @@ function PathLib:is_uri(path)
   return string.match(path, "^%w+://") ~= nil
 end
 
+---Get the URI scheme of a given URI.
+---@param path string
+---@return string
+function PathLib:get_uri_scheme(path)
+  return string.match(path, "^(%w+://)")
+end
+
 ---Change the path separators in a path. Removes duplicate separators.
 ---@param path string
 ---@param sep? '"/"'|'"\\\\"'
@@ -201,11 +208,20 @@ function PathLib:join(...)
   segments = { self:_clean(unpack(segments)) }
   local argc = select("#", unpack(segments))
   local result = ""
-  if not self._is_windows and segments[1] == self.sep then
-    result = self.sep
+  local idx = 1
+
+  if self:is_uri(segments[idx] or "") then
+    result = segments[idx]
+    idx = idx + 1
   end
+
+  if not self._is_windows and segments[idx] == self.sep then
+    result = result .. self.sep
+    idx = idx + 1
+  end
+
   local segc = 0
-  for i = result == "" and 1 or 2, argc do
+  for i = idx, argc do
     if segments[i] ~= nil and segments[i] ~= "" then
       result = result
       .. (segc > 0 and self.sep or "")
@@ -213,6 +229,7 @@ function PathLib:join(...)
       segc = segc + 1
     end
   end
+
   return result
 end
 
@@ -222,18 +239,29 @@ end
 function PathLib:explode(path)
   path = self:_clean(path)
   local parts = {}
+  local i = 1
+
+  if self:is_uri(path) then
+    local scheme, p = path:match("^(%w+://)(.*)")
+    parts[i] = scheme
+    path = p
+    i = i + 1
+  end
+
   local root = self:root(path)
   if root then
-    parts[1] = root
+    parts[i] = root
     if self._is_windows then
       path = path:sub(#root + #self.sep + 1, -1)
     else
       path = path:sub(#root + 1, -1)
     end
   end
+
   for part in path:gmatch(string.format("([^%s]+)%s?", self.sep, self.sep)) do
     parts[#parts+1] = part
   end
+
   return parts
 end
 

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -16,13 +16,17 @@ M.last_draw_time = 0
 ---@field first integer 0 indexed, inclusive
 ---@field last integer Exclusive
 
----@class CompStruct
+---@class CompStruct : { [integer]: CompStruct }
 ---@field _name string
 ---@field comp RenderComponent
-local CompStruct
+
+---@class CompSchema : { [integer]: CompSchema }
+---@field name? string
+---@field context? table
 
 ---@class RenderComponent : Object
 ---@field name string
+---@field context? table
 ---@field parent RenderComponent
 ---@field lines string[]
 ---@field hl HlData[]
@@ -32,7 +36,6 @@ local CompStruct
 ---@field height integer
 ---@field leaf boolean
 ---@field data_root RenderData
----@field context any
 local RenderComponent = oop.create_class("RenderComponent")
 
 ---RenderComponent constructor.
@@ -48,6 +51,9 @@ function RenderComponent:init(name)
   self.leaf = false
 end
 
+---@param parent RenderComponent
+---@param comp_struct CompStruct
+---@param schema CompSchema
 local function create_subcomponents(parent, comp_struct, schema)
   for i, v in ipairs(schema) do
     v.name = v.name or RenderComponent.next_uid()
@@ -75,10 +81,11 @@ function RenderComponent.next_uid()
 end
 
 ---Create a new compoenent
----@param schema table
+---@param schema? CompSchema
 ---@return RenderComponent, CompStruct
 function RenderComponent.create_static_component(schema)
   local comp_struct
+  ---@diagnostic disable-next-line: need-check-nil
   local new_comp = RenderComponent(schema and schema.name or nil)
 
   if schema then
@@ -91,7 +98,7 @@ function RenderComponent.create_static_component(schema)
 end
 
 ---Create and add a new component.
----@param schema table
+---@param schema? CompSchema
 ---@return RenderComponent|CompStruct
 function RenderComponent:create_component(schema)
   local new_comp, comp_struct = RenderComponent.create_static_component(schema)

--- a/lua/diffview/ui/model.lua
+++ b/lua/diffview/ui/model.lua
@@ -1,0 +1,14 @@
+local oop = require("diffview.oop")
+
+local M = {}
+
+---@class Model : Object
+---@field create_comp_schema? fun(data: table): CompSchema
+---@field render? fun(render_data: RenderData)
+local Model = oop.create_class("Model")
+
+Model:virtual("create_comp_schema")
+Model:virtual("render")
+
+M.Model = Model
+return M

--- a/lua/diffview/ui/models/file_tree/file_tree.lua
+++ b/lua/diffview/ui/models/file_tree/file_tree.lua
@@ -1,6 +1,7 @@
 local oop = require("diffview.oop")
 local utils = require("diffview.utils")
-local Node = require("diffview.views.file_tree.node").Node
+local Node = require("diffview.ui.models.file_tree.node").Node
+local Model = require("diffview.ui.model").Model
 
 local M = {}
 
@@ -11,9 +12,9 @@ local M = {}
 ---@field collapsed boolean
 ---@field status string
 
----@class FileTree : Object
+---@class FileTree : Model
 ---@field root Node
-local FileTree = oop.create_class("FileTree")
+local FileTree = oop.create_class("FileTree", Model)
 
 ---FileTree constructor
 ---@param files FileEntry[]|nil
@@ -89,11 +90,14 @@ function FileTree:update_statuses()
   end
 end
 
----@param flatten_dirs boolean
-function FileTree:create_comp_schema(flatten_dirs)
+---@Override
+function FileTree:create_comp_schema(data)
   self.root:sort()
+  ---@type CompSchema
   local schema = {}
 
+  ---@param parent CompSchema
+  ---@param node Node
   local function recurse(parent, node)
     if not node:has_children() then
       parent[#parent + 1] = { name = "file", context = node.data }
@@ -103,7 +107,7 @@ function FileTree:create_comp_schema(flatten_dirs)
     ---@type DirData
     local dir_data = node.data
 
-    if flatten_dirs then
+    if data.flatten_dirs then
       while #node.children == 1 and node.children[1]:has_children() do
         ---@type DirData
         local subdir_data = node.children[1].data

--- a/lua/diffview/ui/models/file_tree/node.lua
+++ b/lua/diffview/ui/models/file_tree/node.lua
@@ -78,6 +78,7 @@ function Node:deep_some(callback)
   self:some(wrap)
 end
 
+---@return Node[]
 function Node:leaves()
   local leaves = {}
   self:deep_some(function(node)

--- a/lua/diffview/ui/panels/commit_log_panel.lua
+++ b/lua/diffview/ui/panels/commit_log_panel.lua
@@ -1,0 +1,127 @@
+local Job = require("plenary.job")
+local Panel = require("diffview.ui.panel").Panel
+local async = require("plenary.async")
+local get_user_config = require("diffview.config").get_config
+local oop = require("diffview.oop")
+local utils = require("diffview.utils")
+
+local api = vim.api
+
+local M = {}
+
+---@class CommitLogPanel : Panel
+---@field git_root string
+---@field rev_arg string
+---@field job_out string[]
+local CommitLogPanel = oop.create_class("CommitLogPanel", Panel)
+
+CommitLogPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
+  wrap = true,
+  breakindent = true,
+})
+
+CommitLogPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
+  buftype = "nowrite",
+  filetype = "git",
+})
+
+---@class CommitLogPanelSpec
+---@field type PanelType
+---@field config PanelConfig
+---@field rev_arg string
+---@field name string
+
+---@param git_root string
+---@param opt CommitLogPanelSpec
+function CommitLogPanel:init(git_root, opt)
+  local user_config = get_user_config()
+  local panel_type = opt.type or user_config.commit_log_panel.type
+  local config = opt.config or user_config.commit_log_panel.win_config
+
+  if panel_type == "split" then
+    if type(config) == "table" then
+      config = vim.tbl_extend("keep", user_config, {
+        position = "bottom",
+        height = 14,
+      })
+    end
+  elseif panel_type == "float" then
+    if type(config) == "table" and vim.tbl_isempty(config) then
+      config = function()
+        local c = {}
+        local viewport_width = vim.o.columns
+        local viewport_height = vim.o.lines
+        c.width = math.min(100, viewport_width)
+        c.height = math.min(24, viewport_height)
+        c.col = math.floor(viewport_width * 0.5 - c.width * 0.5)
+        c.row = math.floor(viewport_height * 0.5 - c.height * 0.5)
+        return c
+      end
+    end
+  end
+
+  CommitLogPanel:super().init(self, {
+    type = panel_type,
+    bufname = opt.name,
+    config = config,
+  })
+  self.git_root = git_root
+  self.rev_arg = opt.rev_arg
+end
+
+CommitLogPanel.update = async.void(function(self, rev_arg)
+  Job:new({
+    command = "git",
+    args = {
+      "log",
+      "--first-parent",
+      "--stat",
+      rev_arg or self.rev_arg,
+    },
+    cwd = self.git_root,
+    on_exit = vim.schedule_wrap(function(job)
+      if job.code ~= 0 then
+        utils.err("Failed to open log!")
+        utils.handle_failed_job(job)
+        return
+      end
+
+      self.job_out = job:result()
+      if not self:is_open() then
+        self:init_buffer()
+      else
+        self:render()
+        self:redraw()
+      end
+      self:focus()
+      vim.cmd("norm! gg")
+    end),
+  }):start()
+end)
+
+---@Override
+function CommitLogPanel:open()
+  CommitLogPanel:super().open(self)
+
+  if self.winid and api.nvim_win_is_valid(self.winid) then
+    utils.set_local(self.winid, {
+      bufhidden = "wipe",
+    })
+  end
+end
+
+function CommitLogPanel:init_buffer_opts()
+end
+
+function CommitLogPanel:update_components()
+end
+
+function CommitLogPanel:render()
+  self.render_data:clear()
+  if self.job_out then
+    self.render_data.lines = utils.vec_slice(self.job_out)
+  end
+end
+
+M.CommitLogPanel = CommitLogPanel
+return M

--- a/lua/diffview/ui/panels/commit_log_panel.lua
+++ b/lua/diffview/ui/panels/commit_log_panel.lua
@@ -23,8 +23,25 @@ CommitLogPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
   filetype = "git",
 })
 
+CommitLogPanel.default_type = "float"
+
+CommitLogPanel.default_config_split = vim.tbl_extend("force", Panel.default_config_split, {
+  position = "bottom",
+  height = 14,
+})
+
+CommitLogPanel.default_config_float = function()
+  local c = vim.deepcopy(Panel.default_config_float)
+  local viewport_width = vim.o.columns
+  local viewport_height = vim.o.lines
+  c.width = math.min(100, viewport_width)
+  c.height = math.min(24, viewport_height)
+  c.col = math.floor(viewport_width * 0.5 - c.width * 0.5)
+  c.row = math.floor(viewport_height * 0.5 - c.height * 0.5)
+  return c
+end
+
 ---@class CommitLogPanelSpec
----@field type PanelType
 ---@field config PanelConfig
 ---@field args string[]
 ---@field name string
@@ -32,36 +49,9 @@ CommitLogPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 ---@param git_root string
 ---@param opt CommitLogPanelSpec
 function CommitLogPanel:init(git_root, opt)
-  local user_config = get_user_config()
-  local panel_type = opt.type or user_config.commit_log_panel.type
-  local config = opt.config or user_config.commit_log_panel.win_config
-
-  if panel_type == "split" then
-    if type(config) == "table" then
-      config = vim.tbl_extend("keep", user_config, {
-        position = "bottom",
-        height = 14,
-      })
-    end
-  elseif panel_type == "float" then
-    if type(config) == "table" and vim.tbl_isempty(config) then
-      config = function()
-        local c = {}
-        local viewport_width = vim.o.columns
-        local viewport_height = vim.o.lines
-        c.width = math.min(100, viewport_width)
-        c.height = math.min(24, viewport_height)
-        c.col = math.floor(viewport_width * 0.5 - c.width * 0.5)
-        c.row = math.floor(viewport_height * 0.5 - c.height * 0.5)
-        return c
-      end
-    end
-  end
-
   CommitLogPanel:super().init(self, {
-    type = panel_type,
     bufname = opt.name,
-    config = config,
+    config = opt.config or get_user_config().commit_log_panel.win_config,
   })
   self.git_root = git_root
   self.args = opt.args or { "-n256" }

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -597,6 +597,41 @@ function M.win_find_buf(bufid, tabpage)
   return result
 end
 
+---Create a new table with only keys that are valid when passed to
+---`nvim_open_win()`.
+---@param config table
+---@param strict? boolean Raise errors if the given config contains illegal keys.
+---@return table
+function M.sanitize_float_config(config, strict)
+  local mask = {
+    relative = true,
+    win = true,
+    anchor = true,
+    width = true,
+    height = true,
+    bufpos = true,
+    row = true,
+    col = true,
+    focusable = true,
+    external = true,
+    zindex = true,
+    style = true,
+    border = true,
+    noautocmd = true,
+  }
+  local result = {}
+
+  for key, value in pairs(config) do
+    if mask[key] then
+      result[key] = vim.deepcopy(value)
+    elseif strict then
+      error(("Window config contained invalid key '%s'!"):format(key))
+    end
+  end
+
+  return result
+end
+
 function M.clear_prompt()
   vim.api.nvim_echo({ { "" } }, false, {})
   vim.cmd("redraw")

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -439,6 +439,21 @@ function M.vec_push(t, ...)
   return t
 end
 
+---Check if a given object is callable.
+---@param obj any
+---@return boolean
+function M.is_callable(obj)
+  if type(obj) == "function" then
+    return true
+  elseif type(obj) == "table" then
+    local mt = getmetatable(obj)
+    if mt then
+      return type(mt.__call) == "function"
+    end
+  end
+  return false
+end
+
 ---@class ListBufsSpec
 ---@field loaded boolean Filter out buffers that aren't loaded.
 ---@field listed boolean Filter out buffers that aren't listed.
@@ -446,6 +461,7 @@ end
 ---@field tabpage integer Filter out buffers that are not displayed in a given tabpage.
 
 ---@param opt? ListBufsSpec
+---@return integer[]
 function M.list_bufs(opt)
   opt = opt or {}
   local bufs

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -186,7 +186,7 @@ function DiffView:update_files(callback)
 
   -- If left is tracking HEAD and right is LOCAL: Update HEAD rev.
   local new_head
-  if self.left.head and self.right.type == RevType.LOCAL then
+  if self.left.track_head and self.right.type == RevType.LOCAL then
     new_head = git.head_rev(self.git_root)
     if new_head and self.left.commit ~= new_head.commit then
       self.left = new_head

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -217,7 +217,7 @@ function DiffView:update_files(callback)
 
       for _, v in ipairs(files) do
         local diff = Diff(v.cur_files, v.new_files, function(aa, bb)
-          return aa.path == bb.path
+          return aa.path == bb.path and aa.oldpath == bb.oldpath
         end)
         local script = diff:create_edit_script()
 

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -49,11 +49,7 @@ FilePanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 function FilePanel:init(git_root, files, path_args, rev_pretty_name)
   local conf = config.get_config()
   FilePanel:super().init(self, {
-    config = {
-      position = conf.file_panel.position,
-      width = conf.file_panel.width,
-      height = conf.file_panel.height,
-    },
+    config = conf.file_panel.win_config,
     bufname = "DiffviewFilePanel",
   })
   self.git_root = git_root

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -16,9 +16,6 @@ local M = {}
 ---@field path_args string[]
 ---@field rev_pretty_name string|nil
 ---@field cur_file FileEntry
----@field width integer
----@field bufid integer
----@field winid integer
 ---@field listing_style '"list"'|'"tree"'
 ---@field tree_options TreeOptions
 ---@field render_data RenderData
@@ -52,9 +49,11 @@ FilePanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 function FilePanel:init(git_root, files, path_args, rev_pretty_name)
   local conf = config.get_config()
   FilePanel:super().init(self, {
-    position = conf.file_panel.position,
-    width = conf.file_panel.width,
-    height = conf.file_panel.height,
+    config = {
+      position = conf.file_panel.position,
+      width = conf.file_panel.width,
+      height = conf.file_panel.height,
+    },
     bufname = "DiffviewFilePanel",
   })
   self.git_root = git_root
@@ -104,11 +103,15 @@ function FilePanel:update_components()
 
     working_files = {
       name = "files",
-      unpack(self.files.working_tree:create_comp_schema(self.tree_options.flatten_dirs)),
+      unpack(self.files.working_tree:create_comp_schema({
+        flatten_dirs = self.tree_options.flatten_dirs
+      })),
     }
     staged_files = {
       name = "files",
-      unpack(self.files.staged_tree:create_comp_schema(self.tree_options.flatten_dirs)),
+      unpack(self.files.staged_tree:create_comp_schema({
+        flatten_dirs = self.tree_options.flatten_dirs
+      })),
     }
   end
 

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -1,11 +1,15 @@
-local utils = require("diffview.utils")
-local git = require("diffview.git.utils")
-local lib = require("diffview.lib")
-local RevType = require("diffview.git.rev").RevType
+local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
 local Event = require("diffview.events").Event
 local FileEntry = require("diffview.views.file_entry").FileEntry
+local RevType = require("diffview.git.rev").RevType
 local api = vim.api
 local async = require("plenary.async")
+local git = require("diffview.git.utils")
+local lib = require("diffview.lib")
+local utils = require("diffview.utils")
+
+---@type CommitLogPanel
+local log_panel
 
 local function prepare_goto_file(view)
   local file = view:infer_cur_file()
@@ -66,7 +70,7 @@ return function(view)
       view.initialized = true
     end,
     close = function()
-      if view.panel:is_cur_win() then
+      if view.panel:is_focused() then
         view.panel:close()
       elseif view:is_cur_tabpage() then
         view:close()
@@ -105,6 +109,21 @@ return function(view)
           view:set_file(item, true)
         end
       end
+    end,
+    open_log = function()
+      if view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL then
+        utils.info("Changes not commited yet. No log available for these changes.")
+        return
+      end
+
+      if not log_panel then
+        log_panel = CommitLogPanel(view.git_root, {
+          name = ("diffview://%s/log/%d/%s"):format(view.git_dir, view.tabpage, "commit_log"),
+        })
+      end
+
+      local rev_arg = ("%s..%s"):format(view.left.commit, view.right.commit or "HEAD")
+      log_panel:update(rev_arg)
     end,
     toggle_stage_entry = function()
       if not (view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL) then
@@ -236,10 +255,10 @@ return function(view)
       view.panel:redraw()
     end,
     focus_files = function()
-      view.panel:focus(true)
+      view.panel:focus()
     end,
     toggle_files = function()
-      view.panel:toggle()
+      view.panel:toggle(true)
     end,
     refresh_files = function()
       view:update_files()

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -110,7 +110,7 @@ return function(view)
         end
       end
     end,
-    open_log = function()
+    open_commit_log = function()
       if view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL then
         utils.info("Changes not commited yet. No log available for these changes.")
         return

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -111,7 +111,12 @@ return function(view)
       end
     end,
     open_commit_log = function()
-      if view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL then
+      if (view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL)
+        or (
+          view.left.type == RevType.COMMIT
+          and vim.tbl_contains({ RevType.INDEX, RevType.LOCAL }, view.right.type)
+          and view.left:is_head(view.git_root)
+        ) then
         utils.info("Changes not commited yet. No log available for these changes.")
         return
       end

--- a/lua/diffview/views/diff/render.lua
+++ b/lua/diffview/views/diff/render.lua
@@ -6,6 +6,7 @@ local renderer = require("diffview.renderer")
 ---@param show_path boolean
 ---@param depth integer|nil
 local function render_file(comp, show_path, depth)
+  ---@type table
   local file = comp.context
   local offset = 0
 
@@ -72,6 +73,7 @@ local function render_file_tree_recurse(depth, comp)
   end
 
   local dir = comp.components[1]
+  ---@type table
   local ctx = dir.context
 
   dir:add_hl(renderer.get_git_hl(ctx.status), 0, 0, 1)
@@ -123,11 +125,16 @@ return function(panel)
   end
 
   panel.render_data:clear()
+  local width = panel:get_width()
+  if not width then
+    local panel_config = panel:get_config()
+    width = panel_config.width
+  end
 
   ---@type RenderComponent
   local comp = panel.components.path.comp
   local line_idx = 0
-  local s = utils.path:shorten(utils.path:vim_fnamemodify(panel.git_root, ":~"), panel.width - 6)
+  local s = utils.path:shorten(utils.path:vim_fnamemodify(panel.git_root, ":~"), width - 6)
   comp:add_hl("DiffviewFilePanelRootPath", line_idx, 0, #s)
   comp:add_line(s)
 
@@ -176,7 +183,7 @@ return function(panel)
       if relpath == "" then
         relpath = "."
       end
-      s = utils.path:shorten(relpath, panel.width - 5)
+      s = utils.path:shorten(relpath, width - 5)
       comp:add_hl("DiffviewFilePanelPath", line_idx, 0, #s)
       comp:add_line(s)
       line_idx = line_idx + 1

--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -61,6 +61,7 @@ FileEntry.bufopts = {
   modifiable = false,
   swapfile = false,
   bufhidden = "hide",
+  undolevels = -1,
 }
 
 ---FileEntry constructor
@@ -370,7 +371,7 @@ function FileEntry._create_buffer(git_root, rev, path, null, callback)
 
   local context
   if rev.type == RevType.COMMIT then
-    context = rev:abbrev()
+    context = rev:abbrev(11)
   elseif rev.type == RevType.INDEX then
     context = ":0:"
   end

--- a/lua/diffview/views/file_entry.lua
+++ b/lua/diffview/views/file_entry.lua
@@ -377,7 +377,7 @@ function FileEntry._create_buffer(git_root, rev, path, null, callback)
   end
 
   -- stylua: ignore
-  local fullname = "diffview://" .. utils.path:join(git_root, ".git", context, path)
+  local fullname = utils.path:join("diffview://", git_root, ".git", context, path)
   for option, value in pairs(FileEntry.bufopts) do
     api.nvim_buf_set_option(bn, option, value)
   end
@@ -388,7 +388,7 @@ function FileEntry._create_buffer(git_root, rev, path, null, callback)
     local i = 1
     repeat
       -- stylua: ignore
-      fullname = "diffview://" .. utils.path:join(git_root, ".git", context, i, path)
+      fullname = utils.path:join("diffview://", git_root, ".git", context, i, path)
       ok = pcall(api.nvim_buf_set_name, bn, fullname)
       i = i + 1
     until ok

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -79,11 +79,7 @@ FileHistoryPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 function FileHistoryPanel:init(parent, git_root, entries, path_args, raw_args, log_options, opt)
   local conf = config.get_config()
   FileHistoryPanel:super().init(self, {
-    config = {
-      position = conf.file_history_panel.position,
-      width = conf.file_history_panel.width,
-      height = conf.file_history_panel.height,
-    },
+    config = conf.file_history_panel.win_config,
     bufname = "DiffviewFileHistoryPanel",
   })
   self.parent = parent

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -39,10 +39,6 @@ local perf_update = PerfTimer("[FileHistoryPanel] update")
 ---@field cur_item {[1]: LogEntry, [2]: FileEntry}
 ---@field single_file boolean
 ---@field updating boolean
----@field width integer
----@field height integer
----@field bufid integer
----@field winid integer
 ---@field render_data RenderData
 ---@field option_panel FHOptionPanel
 ---@field option_mapping string
@@ -52,7 +48,7 @@ local FileHistoryPanel = oop.create_class("FileHistoryPanel", Panel)
 
 FileHistoryPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
   cursorline = true,
-  winhl = table.concat({
+  winhl = {
     "EndOfBuffer:DiffviewEndOfBuffer",
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
@@ -60,7 +56,7 @@ FileHistoryPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",
     "StatusLineNC:DiffviewStatuslineNC",
-  }, ","),
+  },
 })
 
 FileHistoryPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
@@ -81,9 +77,11 @@ FileHistoryPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 function FileHistoryPanel:init(git_root, entries, path_args, raw_args, log_options, opt)
   local conf = config.get_config()
   FileHistoryPanel:super().init(self, {
-    position = conf.file_history_panel.position,
-    width = conf.file_history_panel.width,
-    height = conf.file_history_panel.height,
+    config = {
+      position = conf.file_history_panel.position,
+      width = conf.file_history_panel.width,
+      height = conf.file_history_panel.height,
+    },
     bufname = "DiffviewFileHistoryPanel",
   })
   self.git_root = git_root

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -29,6 +29,7 @@ local perf_update = PerfTimer("[FileHistoryPanel] update")
 ---@field grep string
 
 ---@class FileHistoryPanel : Panel
+---@field parent FileHistoryView
 ---@field git_root string
 ---@field entries LogEntry[]
 ---@field path_args string[]
@@ -68,13 +69,14 @@ FileHistoryPanel.bufopts = vim.tbl_extend("force", Panel.bufopts, {
 ---@field rev_arg string
 
 ---FileHistoryPanel constructor.
+---@param parent FileHistoryView
 ---@param git_root string
 ---@param entries LogEntry[]
 ---@param path_args string[]
 ---@param log_options LogOptions
 ---@param opt FileHistoryPanelSpec
 ---@return FileHistoryPanel
-function FileHistoryPanel:init(git_root, entries, path_args, raw_args, log_options, opt)
+function FileHistoryPanel:init(parent, git_root, entries, path_args, raw_args, log_options, opt)
   local conf = config.get_config()
   FileHistoryPanel:super().init(self, {
     config = {
@@ -84,6 +86,7 @@ function FileHistoryPanel:init(git_root, entries, path_args, raw_args, log_optio
     },
     bufname = "DiffviewFileHistoryPanel",
   })
+  self.parent = parent
   self.git_root = git_root
   self.entries = entries
   self.path_args = path_args

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -34,6 +34,7 @@ function FileHistoryView:init(opt)
   self.raw_args = opt.raw_args
   self.rev_arg = opt.rev_arg
   self.panel = FileHistoryPanel(
+    self,
     self.git_root,
     {},
     self.path_args,

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -219,11 +219,11 @@ end
 ---file entry under the cursor. Otherwise return the file open in the view.
 ---Returns nil if no file is open in the view, or there is no entry under the
 ---cursor in the file panel.
----@return FileEntry|nil
+---@return FileEntry?
 function FileHistoryView:infer_cur_file()
   if self.panel:is_focused() then
     local item = self.panel:get_item_at_cursor()
-    if not item:instanceof(FileEntry) then
+    if item and not item:instanceof(FileEntry) then
       return item.files[1]
     end
     return item

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -125,7 +125,7 @@ return function(view)
         end
       end
     end,
-    open_log = function()
+    open_commit_log = function()
       local file = view:infer_cur_file()
       if file then
         if not log_panel then

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -53,23 +53,6 @@ return function(view)
         end
       end
     end,
-    win_closed = function(winid)
-      if winid and winid == view.panel.option_panel.winid then
-        local op = view.panel.option_panel
-        if not vim.deep_equal(op.option_state, view.panel.log_options) then
-          vim.schedule(function ()
-            op.option_state = nil
-            view.panel.option_panel.winid = nil
-            ---@diagnostic disable-next-line: unused-local
-            view.panel:update_entries(function(entries, status)
-              if not view.panel:cur_file() then
-                view:next_item()
-              end
-            end)
-          end)
-        end
-      end
-    end,
     open_in_diffview = function()
       if view.panel:is_focused() then
         local item = view.panel:get_item_at_cursor()

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -86,6 +86,22 @@ function FHOptionPanel:init(parent)
     self:render()
     self:redraw()
   end)
+
+  self:on_autocmd("WinClosed", {
+    callback = function()
+      if not vim.deep_equal(self.option_state, self.parent.log_options) then
+        vim.schedule(function ()
+          self.option_state = nil
+          self.winid = nil
+          self.parent:update_entries(function(_, _)
+            if not self.parent:cur_file() then
+              self.parent.parent:next_item()
+            end
+          end)
+        end)
+      end
+    end,
+  })
 end
 
 ---@Override

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -16,7 +16,7 @@ local FHOptionPanel = oop.create_class("FHOptionPanel", Panel)
 
 FHOptionPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
   cursorline = true,
-  winhl = table.concat({
+  winhl = {
     "EndOfBuffer:DiffviewEndOfBuffer",
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
@@ -24,7 +24,7 @@ FHOptionPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",
     "StatusLineNC:DiffviewStatuslineNC",
-  }, ","),
+  },
 })
 
 FHOptionPanel.bufopts = {
@@ -61,7 +61,9 @@ end
 ---@return FHOptionPanel
 function FHOptionPanel:init(parent)
   FHOptionPanel:super().init(self, {
-    position = "bottom",
+    config = {
+      position = "bottom",
+    },
     bufname = "DiffviewFHOptionPanel",
   })
   self.parent = parent

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -2,7 +2,6 @@ local utils = require("diffview.utils")
 local config = require("diffview.config")
 local renderer = require("diffview.renderer")
 local logger = require("diffview.logger")
-local Form = require("diffview.ui.panel").Form
 local PerfTimer = require("diffview.perf").PerfTimer
 
 ---@type PerfTimer
@@ -82,9 +81,6 @@ local function render_entries(parent, entries, updating)
     if i > #parent or (updating and i > 128) then
       break
     end
-    if not entry.status then
-      print(vim.inspect(entry, { depth = 2 }))
-    end
     local entry_struct = parent[i]
     local line_idx = 0
     local offset = 0
@@ -104,7 +100,7 @@ local function render_entries(parent, entries, updating)
       offset = #s
       local counter = " "
         .. utils.str_left_pad(tostring(#entry.files), #tostring(max_num_files))
-        .. " files"
+        .. (" file%s"):format(#entry.files > 1 and "s" or " ")
       comp:add_hl("DiffviewFilePanelCounter", line_idx, offset, offset + #counter)
       s = s .. counter
     end
@@ -173,10 +169,10 @@ end
 local function prepare_panel_cache(panel)
   local c = {}
   cache[panel] = c
-  c.root_path = panel.form == Form.COLUMN
+  c.root_path = panel.state.form == "column"
       and utils.path:shorten(
         utils.path:vim_fnamemodify(panel.git_root, ":~"),
-        panel.width - 6
+        panel:get_config().width - 6
       )
     or utils.path:vim_fnamemodify(panel.git_root, ":~")
   c.args = table.concat(panel.raw_args, " ")

--- a/lua/diffview/views/standard/standard_view.lua
+++ b/lua/diffview/views/standard/standard_view.lua
@@ -47,7 +47,7 @@ function StandardView:init_layout()
   vim.cmd("belowright " .. split_cmd)
   self.right_winid = api.nvim_get_current_win()
   FileEntry.load_null_buffer(self.right_winid)
-  self.panel:open()
+  self.panel:focus()
   self:post_layout()
 end
 


### PR DESCRIPTION
Resolves #117.

This implements a commit log panel that lets you open a window with the full
commit descriptions for the range of git revs currently being diffed. This works
in both standard diffviews and file history views. From either the file panel,
or the file history panel, press `L` to open the commit log. In the file history
panel this will target the commit under the cursor.

### What will break?

The PR also refactors the internal representation of a panel (the various
interactive windows used in the plugin). Among other things, this allows all
panels to be configured as floating windows if so desired. The way panels are
configured has been changed and extended in a manner that is incompatible with
the way it was done before. To update your config, just move all the window
related options into a new table key `win_config`:

```lua
-- CHANGE THIS:
require("diffview").setup({
  -- ...
  file_panel = {
    position = "left",
    width = 35,
    height = 16,
    -- (Other options...)
  },
})

-- TO THIS:
require("diffview").setup({
  -- ...
  file_panel = {
    win_config = {
      position = "left",
      width = 35,
      height = 16,
    },
    -- (Other options...)
  },
})
```

This goes for both the `file_panel` and the `file_history_panel` config. To see
all the available options for `win_config`, see `:h diffview-config-win_config`.

This information is also available in the editor as `:h
diffview.changelog-136`.