### PR TITLE
feat!: More file history options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ require("diffview").setup({
     },
   },
   file_history_panel = {
-    log_options = {
-      max_count = 256,      -- Limit the number of commits
-      follow = false,       -- Follow renames (only for single file)
-      all = false,          -- Include all refs under 'refs/' including HEAD
-      merges = false,       -- List only merge commits
-      no_merges = false,    -- List no merge commits
-      reverse = false,      -- List commits in reverse order
+    log_options = {   -- See ':h diffview-config-log_options'
+      single_file = {
+        diff_merges = "combined",
+      },
+      multiple_files = {
+        diff_merges = "first-parent",
+      },
     },
-    win_config = {          -- See ':h diffview-config-win_config'
+    win_config = {    -- See ':h diffview-config-win_config'
       position = "bottom",
       height = 16,
     },
@@ -97,7 +97,7 @@ require("diffview").setup({
       -- tabpage is a Diffview.
       ["<tab>"]      = actions.select_next_entry, -- Open the diff for the next file
       ["<s-tab>"]    = actions.select_prev_entry, -- Open the diff for the previous file
-      ["gf"]         = actions.goto_file,         -- Open the file in a new split in previous tabpage
+      ["gf"]         = actions.goto_file,         -- Open the file in a new split in the previous tabpage
       ["<C-w><C-f>"] = actions.goto_file_split,   -- Open the file in a new split
       ["<C-w>gf"]    = actions.goto_file_tab,     -- Open the file in a new tabpage
       ["<leader>e"]  = actions.focus_files,       -- Bring focus to the files panel
@@ -240,17 +240,20 @@ panel.
 
 ![file-history-multi](https://user-images.githubusercontent.com/2786478/131269782-f4184640-6d73-4226-b425-feccb5002dd0.png)
 
-The file history view allows you to list all the commits that changed a given
-file or directory, and view the changes made in a diff split. Open a file
-history view for your current file by calling `:DiffviewFileHistory`.
+The file history view allows you to list all the commits that affected a given
+file or directory, and view the changes made in a diff split. This is a
+porcelain interface for git-log. Open a file history view for your current file
+by calling `:DiffviewFileHistory %`.
 
 ## Usage
 
-### `:DiffviewOpen [git rev] [args] [ -- {paths...}]`
+### `:DiffviewOpen [git rev] [options] [ -- {paths...}]`
 
 Calling `:DiffviewOpen` with no args opens a new Diffview that compares against
 the current index. You can also provide any valid git rev to view only changes
-for that rev. Examples:
+for that rev.
+
+Examples:
 
 - `:DiffviewOpen`
 - `:DiffviewOpen HEAD~2`
@@ -263,7 +266,8 @@ You can also provide additional paths to narrow down what files are shown:
 
 - `:DiffviewOpen HEAD~2 -- lua/diffview plugin`
 
-For information about additional `[args]`, visit the [documentation](https://github.com/sindrets/diffview.nvim/blob/main/doc/diffview.txt).
+For information about additional `[options]`, visit the
+[documentation](https://github.com/sindrets/diffview.nvim/blob/main/doc/diffview.txt).
 
 Additional commands for convenience:
 
@@ -276,13 +280,24 @@ Additional commands for convenience:
 With a Diffview open and the default key bindings, you can cycle through changed
 files with `<tab>` and `<s-tab>` (see configuration to change the key bindings).
 
-### `:DiffviewFileHistory [paths] [args]`
+### `:DiffviewFileHistory [paths] [options]`
 
-Opens a new file history view that lists all commits that changed a given file
-or directory. If no `[paths]` are given, defaults to the current file. Multiple
-`[paths]` may be provided. If you want to view the file history for all changed
-files for every commit, simply call `:DiffviewFileHistory .` (assuming your cwd
-is the top level of the git repository).
+Opens a new file history view that lists all commits that affected the given
+paths. This is a porcelain interface for git-log.
+
+If no `[paths]` are given, defaults to the top-level of the git repository. The
+top-level will be inferred from the current buffer when possible, otherwise the
+cwd is used. Multiple `[paths]` may be provided and git pathspec is supported.
+
+Examples:
+
+- `:DiffviewFileHistory`
+- `:DiffviewFileHistory %`
+- `:DiffviewFileHistory path/to/some/file.txt`
+- `:DiffviewFileHistory path/to/some/directory`
+- `:DiffviewFileHistory include/this and/this :!but/not/this`
+- `:DiffviewFileHistory --range=origin..HEAD`
+- `:DiffviewFileHistory --range=feat/example-branch`
 
 ## Restoring Files
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ require("diffview").setup({
       single_file = {
         diff_merges = "combined",
       },
-      multiple_files = {
+      multi_file = {
         diff_merges = "first-parent",
       },
     },

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -60,15 +60,15 @@ Example configuration with default settings:
         },
       },
       file_history_panel = {
-        log_options = {
-          max_count = 256,      -- Limit the number of commits
-          follow = false,       -- Follow renames (only for single file)
-          all = false,          -- Include all refs under 'refs/' including HEAD
-          merges = false,       -- List only merge commits
-          no_merges = false,    -- List no merge commits
-          reverse = false,      -- List commits in reverse order
+        log_options = {   -- See |diffview-config-log_options|
+          single_file = {
+            diff_merges = "combined",
+          },
+          multiple_files = {
+            diff_merges = "first-parent",
+          },
         },
-        win_config = {          -- See |diffview-config-win_config|
+        win_config = {    -- See |diffview-config-win_config|
           position = "bottom",
           height = 16,
         },
@@ -241,6 +241,24 @@ win_config                                      *diffview-config-win_config*
                   return c
                 end,
 <
+
+
+log_options                                     *diffview-config-log_options*
+        Type: `table`, Default: (see example config above)
+
+        This table allows you to control the default options that are passed
+        to git-log in order to produce the file history. The table is divided
+        into the sub-tables `single_file`, and `multiple_files`. This allows
+        you to define different default log options for history targeting
+        singular files, and history targeting multiple paths, and/or
+        directories.
+
+        Fields:~
+            {single_file} (`LogOptions`)
+                See |diffview.git.LogOptions|.
+
+            {multiple_files} (`LogOptions`)
+                See |diffview.git.LogOptions|.
 
 default_args                                    *diffview-config-default_args*
         Type: `table<string, string[]>`, Default: `{}`
@@ -587,8 +605,8 @@ select_entry                                    *diffview-actions-select_entry*
         Think of this as a general "interact" action. In the file panel, and
         the file history panel, this will open the file under the cursor. If
         the entry under the cursor is a directory, or a history entry with
-        multiple files, this will toggle the entry's collapsed state. In the
-        option panel this will interact with the option under the cursor.
+        multiple files, this will collapse or open the entry. In the option
+        panel this will interact with the option under the cursor.
 
 select_next_entry                               *diffview-actions-select_next_entry*
         Contexts: `view`, `file_panel`, `file_history_panel`
@@ -660,14 +678,14 @@ split. To change the alignment add either `horizontal` or `vertical` to your
 COMMANDS                                        *diffview-commands*
 
                                                 *:DiffviewOpen*
-:DiffviewOpen [git-rev] [args] [ -- {paths...}]
+:DiffviewOpen [git-rev] [options] [ -- {paths...}]
                         Opens a new Diffview that compares against [git-rev].
                         If no [git-rev] is given, defaults to comparing
                         against the index. Additional {paths...} can be
                         provided to narrow down what files are shown. If the
-                        `-C` flag is not defined, the git root is determined
-                        from the current buffer when possible. Otherwise it's
-                        determined from the cwd.
+                        `-C` flag is not defined, the git top-level is
+                        determined from the current buffer when possible.
+                        Otherwise it's determined from the cwd.
                         Examples:
 >
         :DiffviewOpen
@@ -679,7 +697,7 @@ COMMANDS                                        *diffview-commands*
         :DiffviewOpen HEAD~2 -- lua/diffview plugin
         :DiffviewOpen d4a7b0d -uno
 <
-    Args:~
+    Options:~
         -u[value], --untracked-files[={value}]
                         Specify whether or not to show untracked files. If
                         flag is given without value; defaults to `true`.
@@ -707,13 +725,17 @@ COMMANDS                                        *diffview-commands*
                         the initial set of files, this option does nothing.
 
                                                 *:DiffviewFileHistory*
-:DiffviewFileHistory [paths] [args]
+:DiffviewFileHistory [paths] [options]
                         Opens a new file history view that lists all commits
-                        that changed a given file or directory. If no [paths]
-                        are given, defaults to the current file. Multiple
-                        [paths] may be provided and git pathspec is supported
-                        (see `$ man gitglossary(7)` for information about
-                        pathspec).
+                        that affected the given paths. This is a porcelain
+                        interface for git-log.
+
+                        If no [paths] are given, defaults to the top-level of
+                        the git repository. The top-level will be inferred
+                        from the current buffer when possible, otherwise the
+                        cwd is used. Multiple [paths] may be provided and git
+                        pathspec is supported (see `:Man gitglossary(7)` for
+                        information about pathspec).
 
                         From the file history panel (the panel listing the
                         commits) you can open an option panel by pressing
@@ -724,18 +746,30 @@ COMMANDS                                        *diffview-commands*
                         that are shown directly in the panel, preceding the
                         flags' descriptions.
 
+                        NOTE: Commits are only listed if git-log is able to
+                        show its file stats given your currently configured
+                        log options. As such pay attention to the value of
+                        `--diff-merges`, as this controls how git-log treats
+                        merge commits and subsequently it's willingness to
+                        show stats for these commits. Setting
+                        `--diff-merges=off` will tell git-log to never compare
+                        merge commits, and as such they won't show up in the
+                        file history view.
+
                         Examples:
 >
         :DiffviewFileHistory
+        :DiffviewFileHistory %
         :DiffviewFileHistory path/to/some/file.txt
         :DiffviewFileHistory path/to/some/directory
         :DiffviewFileHistory multiple/paths foo/bar baz/qux
         :DiffviewFileHistory --base=HEAD~4
         :DiffviewFileHistory --base=LOCAL
         :DiffviewFileHistory --range=origin..HEAD
+        :DiffviewFileHistory --range=feat/some-branch
 <
 
-    Args:~
+    Options:~
         --base={git-rev}
                         Specify a base git rev from which the right side of
                         the diff will be created. Use the special value
@@ -746,6 +780,48 @@ COMMANDS                                        *diffview-commands*
 
         -C{path}        Run as if git was started in {path} instead of the
                         current working directory.
+
+        NOTE: All following options are described in far more detail in the
+        man page for git-log. See `:Man git-log(1)` for more information.
+
+        --follow        Follow renames (only for single file).
+
+        --first-parent  Follow only the first parent upon seeing a merge
+                        commit.
+
+        --show-pulls    Show merge commits that are not TREESAME to its first
+                        parent, but are to a later parent.
+
+        --all           Include all refs.
+
+        --merges        List only merge commits.
+
+        --no-merges     List no merge commits.
+
+        --reverse       List commits in reverse order.
+
+        -n{n}, --max-count={n}
+                        Limit the number of commits.
+
+        --diff-merges={value}
+                        Determines how merge commits are treated. {value} can
+                        be one of:
+                            • `off`
+                            • `on`
+                            • `first-parent`
+                            • `separate`
+                            • `combined`
+                            • `dense-combined`
+                            • `remerge`
+
+        --author={pattern}
+                        Limit the commits output to ones with author/committer
+                        header lines that match the specified pattern (regular
+                        expression).
+
+        --grep={pattern}
+                        Limit the commits output to ones with log message that
+                        matches the specified pattern (regular expression).
 
                                                 *:DiffviewClose*
 :DiffviewClose          Close the active Diffview.
@@ -966,73 +1042,149 @@ https://gist.github.com/sindrets/b750723f5f23182904f70a6274106304
 
 CDiffView                                       *diffview.api.views.diff.diff_view.CDiffView*
 
-    Class that represents a custom Diffview.
+        Class that represents a custom Diffview.
 
-    CDiffView({opt})
+        CDiffView({opt})
 
-        Parameters: ~
-            {opt}   (table)   Table containing the args passed to the view
-                              constructor.
+            Parameters: ~
+                {opt} (table)
+                    Table containing the args passed to the view constructor.
 
-        Fields: ~
-            {git_root} (string)         Absolute path to the toplevel git
-                                        directory.
-            {left} (Rev)                The git rev representing the left
-                                        window in the diffview.
-            {right} (Rev)               The git rev representing the right
-                                        window in the diffview.
-            {files} (FileDict)          List of file data used to create the
-                                        file entries in the view.
-            {update_files} (function)   This function should return an updated
-                                        list of `FileData`, and is called from
-                                        `View:update_files`.
-                Parameters: ~
-                    {view} (CDiffView)  The CDiffView object that called the
-                                        function.
+            Fields: ~
+                {git_root} (string)
+                    Absolute path to the toplevel git
+                                            directory.
 
-            {get_file_data} (function)  This should return a list of lines that
-                                        make up the buffer indicated by `path`
-                                        and `split`.
-                Parameters: ~
-                    {kind} ("working"|"staged")
-                    {path} (string)             Path to the file, relative to
-                                                git root.
-                    {split} ("left"|"right")
+                {left} (Rev)
+                    The git rev representing the left window in the diffview.
+
+                {right} (Rev)
+                    The git rev representing the right window in the diffview.
+
+                {files} (FileDict)
+                    List of file data used to create the file entries in the
+                    view.
+
+                {update_files} (function)
+                    This function should return an updated list of `FileData`, and
+                    is called from `View:update_files`.
+
+                    Parameters: ~
+                        {view} (CDiffView)
+                            The CDiffView object that called the function.
+
+
+                {get_file_data} (function)
+                    This should return a list of lines that make up the buffer
+                    indicated by `path` and `split`.
+
+                    Parameters: ~
+                        {kind} ("working"|"staged")
+                        {path} (string)             Path to the file, relative to
+                                                    git root.
+                        {split} ("left"|"right")
 
 FileDict                                        *diffview.git.FileDict*
 
-    Fields:~
-        {working} (FileData[])
-        {staged}  (FileData[])
+        Fields:~
+            {working} (FileData[])
+            {staged}  (FileData[])
 
 FileData                                        *diffview.api.views.diff.diff_view.FileData*
 
-    Table that contains the metadata used to create file entries.
+        Table that contains the metadata used to create file entries.
 
-    Fields: ~
-        {path} (string)         Path relative to git root.
-        {oldpath} (string|nil)  If the file has been renamed, this should be
-                                the old path, otherwise nil.
-        {status} (string)       Git status symbol. Can be one of:
-                                `A`, `?`, `M`, `R`, `C`, `T`, `U`, `X`, `D`, `B`
-                                See `man git-status` for the definition of the
-                                different symbols.
-        {stats} (GitStats|nil)  Table describing number of additions and
-                                deletions in the file.
-        {left_null} (boolean)   If true, indicates that the left diff buffer
-                                should be represented by the null buffer.
-        {right_null} (boolean)  If true, indicates that the right diff buffer
-                                should be represented by the null buffer.
-        {selected} (boolean)    If true, indicates that this should be the
-                                initially selected file.
+        Fields: ~
+            {path} (string)
+                Path relative to git root.
+
+            {oldpath} (string|nil)
+                If the file has been renamed, this should be the old path,
+                otherwise nil.
+
+            {status} (string)
+                Git status symbol. Can be one of: `A`, `?`, `M`, `R`, `C`,
+                `T`, `U`, `X`, `D`, `B` See `:Man git-status(1)` for the
+                definition of the different symbols.
+
+            {stats} (GitStats|nil)
+                Table describing number of additions and deletions in the
+                file.
+
+            {left_null} (boolean)
+                If true, indicates that the left diff buffer should be
+                represented by the null buffer.
+
+            {right_null} (boolean)
+                If true, indicates that the right diff buffer should be
+                represented by the null buffer.
+
+            {selected} (boolean)
+                If true, indicates that this should be the initially selected
+                file.
 
 GitStats                                        *diffview.views.file_entry.GitStats*
 
-    Table describing number of additions and deletions in a file.
+        Table describing number of additions and deletions in a file.
 
-    Fields: ~
-        {additions} (integer)   Number of additons in the file.
-        {deletions} (integer)   Number of deletions in the file.
+        Fields: ~
+            {additions} (integer)
+                Number of additons in the file.
+
+            {deletions} (integer)
+                Number of deletions in the file.
+
+LogOptions                                      *diffview.git.LogOptions*
+
+        Table controlling the options passed to git-log.
+
+        Fields:~
+            NOTE: All these options are described in far more detail in the
+            man page for git-log. See `:Man git-log(1)` for more information.
+
+            {follow} (boolean)
+                Follow renames (only for single file).
+
+            {first_parent} (boolean)
+                Follow only the first parent upon seeing a merge commit.
+
+            {show_pulls} (boolean)
+                Show merge commits that are not TREESAME to its first parent,
+                but are to a later parent.
+
+            {all} (boolean)
+                Include all refs.
+
+            {merges} (boolean)
+                List only merge commits.
+
+            {no_merges} (boolean)
+                List no merge commits.
+
+            {reverse} (boolean)
+                List commits in reverse order.
+
+            {max_count} (integer)
+                Limit the number of commits.
+
+            {diff_merges} (string)
+                Determines how merge commits are treated. The value can be one
+                of:
+                    • `"off"`
+                    • `"on"`
+                    • `"first-parent"`
+                    • `"separate"`
+                    • `"combined"`
+                    • `"dense-combined"`
+                    • `"remerge"`
+
+            {author} (string)
+                Limit the commits output to ones with author/committer header
+                lines that match the specified pattern (regular expression).
+
+            {grep} (string)
+                Limit the commits output to ones with log message that matches
+                the specified pattern (regular expression).
 
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -64,7 +64,7 @@ Example configuration with default settings:
           single_file = {
             diff_merges = "combined",
           },
-          multiple_files = {
+          multi_file = {
             diff_merges = "first-parent",
           },
         },
@@ -248,16 +248,15 @@ log_options                                     *diffview-config-log_options*
 
         This table allows you to control the default options that are passed
         to git-log in order to produce the file history. The table is divided
-        into the sub-tables `single_file`, and `multiple_files`. This allows
-        you to define different default log options for history targeting
-        singular files, and history targeting multiple paths, and/or
-        directories.
+        into the sub-tables `single_file`, and `multi_file`. This allows you
+        to define different default log options for history targeting singular
+        files, and history targeting multiple paths, and/or directories.
 
         Fields:~
             {single_file} (`LogOptions`)
                 See |diffview.git.LogOptions|.
 
-            {multiple_files} (`LogOptions`)
+            {multi_file} (`LogOptions`)
                 See |diffview.git.LogOptions|.
 
 default_args                                    *diffview-config-default_args*
@@ -792,6 +791,8 @@ COMMANDS                                        *diffview-commands*
         --show-pulls    Show merge commits that are not TREESAME to its first
                         parent, but are to a later parent.
 
+        --reflog        Include all reachable objects mentioned by reflogs.
+
         --all           Include all refs.
 
         --merges        List only merge commits.
@@ -1152,6 +1153,9 @@ LogOptions                                      *diffview.git.LogOptions*
                 Show merge commits that are not TREESAME to its first parent,
                 but are to a later parent.
 
+            {reflog} (boolean)
+                Include all reachable objects mentioned by reflogs.
+
             {all} (boolean)
                 Include all refs.
 
@@ -1163,6 +1167,9 @@ LogOptions                                      *diffview.git.LogOptions*
 
             {reverse} (boolean)
                 List commits in reverse order.
+
+            {rev_range} (string)
+                List only the commits in the specified revision range.
 
             {max_count} (integer)
                 Limit the number of commits.

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -22,13 +22,25 @@ function ArgObject:init(flags, args, post_args)
   self.post_args = post_args
 end
 
+---@class ArgObjectGetFlagSpec
+---@field plain boolean Never cast string values to booleans.
+
 ---Get a flag value.
----@vararg ... string[] Flag synonyms
----@return any
-function ArgObject:get_flag(...)
-  for _, name in ipairs({ ... }) do
-    if self.flags[name] ~= nil then
-      return self.flags[name]
+---@param names string|string[] Flag synonyms
+---@param opt? ArgObjectGetFlagSpec
+---@return string|boolean
+function ArgObject:get_flag(names, opt)
+  opt = opt or {}
+  if type(names) ~= "table" then
+    names = { names }
+  end
+  for _, name in ipairs(names) do
+    local v = self.flags[name]
+    if v ~= nil then
+      if not opt.plain and (v == "true" or v == "false") then
+        v = v == "true" and true or false
+      end
+      return v
     end
   end
 end
@@ -44,7 +56,7 @@ function FlagValueMap:init()
 end
 
 ---@param flag_synonyms string[]
----@param producer string[]|fun(name_lead: string, arg_lead: string): string[]
+---@param producer? string[]|fun(name_lead: string, arg_lead: string): string[]
 function FlagValueMap:put(flag_synonyms, producer)
   for _, flag in ipairs(flag_synonyms) do
     if flag:sub(1, 1) ~= "-" then
@@ -54,7 +66,7 @@ function FlagValueMap:put(flag_synonyms, producer)
         flag = "-" .. flag
       end
     end
-    self.map[flag] = producer
+    self.map[flag] = producer or { "true", "false" }
     self.map[#self.map+1] = flag
   end
 end

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -24,6 +24,8 @@ end
 
 ---@class ArgObjectGetFlagSpec
 ---@field plain boolean Never cast string values to booleans.
+---@field expect_string boolean Inferred boolean values are changed to be empty strings.
+---@field no_empty boolean Return nil if the value is an empty string.
 
 ---Get a flag value.
 ---@param names string|string[] Flag synonyms
@@ -37,7 +39,12 @@ function ArgObject:get_flag(names, opt)
   for _, name in ipairs(names) do
     local v = self.flags[name]
     if v ~= nil then
-      if not opt.plain and (v == "true" or v == "false") then
+      if opt.expect_string and v == "true" then
+        if opt.no_empty then
+          return nil
+        end
+        v = ""
+      elseif not opt.plain and (v == "true" or v == "false") then
         v = v == "true" and true or false
       end
       return v

--- a/lua/diffview/bootstrap.lua
+++ b/lua/diffview/bootstrap.lua
@@ -82,6 +82,7 @@ _G.DiffviewGlobal = {
   debug_level = tonumber(os.getenv("DEBUG_DIFFVIEW")) or 0,
   ---@type EventEmitter
   emitter = require("diffview.events").EventEmitter(),
+  state = {},
   bootstrap_done = true,
   bootstrap_ok = true,
 }

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -43,12 +43,17 @@ M.defaults = {
   },
   file_history_panel = {
     log_options = {
-      max_count = 256,
       follow = false,
+      first_parent = false,
+      show_pulls = true,
       all = false,
       merges = false,
       no_merges = false,
       reverse = false,
+      max_count = 256,
+      diff_merges = "on",
+      author = nil,
+      grep = nil,
     },
     win_config = {
       position = "bottom",

--- a/lua/diffview/debounce.lua
+++ b/lua/diffview/debounce.lua
@@ -1,14 +1,37 @@
 local utils = require "diffview.utils"
 local M = {}
 
+---@class ManagedFunc
+---@field close fun() Release timer handle.
+
+---@return ManagedFunc
+local function wrap(timer, fn)
+  local function close()
+    timer:stop()
+    timer:close()
+  end
+
+  return setmetatable({}, {
+    __call = function(_, ...)
+      fn(...)
+    end,
+    __index = function(self, k)
+      if k == "close" then
+        return close
+      end
+      return self[k]
+    end,
+  })
+end
+
 ---Debounces a function on the leading edge.
 ---@param ms integer Timeout in ms
 ---@param fn function Function to debounce
----@returns function Debounced function.
+---@returns ManagedFunc Debounced function.
 function M.debounce_leading(ms, fn)
   local timer = vim.loop.new_timer()
   local running = false
-  return function(...)
+  return wrap(timer, function(...)
     timer:start(ms, 0, function()
       timer:stop()
       running = false
@@ -17,32 +40,32 @@ function M.debounce_leading(ms, fn)
       running = true
       fn(...)
     end
-  end
+  end)
 end
 
 ---Debounces a function on the trailing edge.
 ---@param ms integer Timeout in ms
 ---@param fn function Function to debounce
----@returns function Debounced function.
+---@returns ManagedFunc Debounced function.
 function M.debounce_trailing(ms, fn)
   local timer = vim.loop.new_timer()
-  return function(...)
+  return wrap(timer, function(...)
     local args = utils.tbl_pack(...)
     timer:start(ms, 0, function()
       timer:stop()
       fn(utils.tbl_unpack(args))
     end)
-  end
+  end)
 end
 
 ---Throttles a function on the leading edge.
 ---@param ms integer Timeout in ms
 ---@param fn function Function to throttle
----@returns function throttled function.
+---@returns ManagedFunc throttled function.
 function M.throttle_leading(ms, fn)
   local timer = vim.loop.new_timer()
   local running = false
-  return function(...)
+  return wrap(timer, function(...)
     if not running then
       timer:start(ms, 0, function()
         running = false
@@ -51,18 +74,18 @@ function M.throttle_leading(ms, fn)
       running = true
       fn(...)
     end
-  end
+  end)
 end
 
 ---Throttles a function on the trailing edge.
 ---@param ms integer Timeout in ms
 ---@param fn function Function to throttle
----@returns function throttled function.
+---@returns ManagedFunc throttled function.
 function M.throttle_trailing(ms, fn)
   local timer = vim.loop.new_timer()
   local running = false
   local args
-  return function(...)
+  return wrap(timer, function(...)
     args = utils.tbl_pack(...)
     if not running then
       timer:start(ms, 0, function()
@@ -72,7 +95,7 @@ function M.throttle_trailing(ms, fn)
       end)
       running = true
     end
-  end
+  end)
 end
 
 return M

--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -359,7 +359,7 @@ local function structure_fh_data(namestat_data, numstat_data)
     time = tonumber(time),
     time_offset = time_offset,
     rel_date = namestat_data[4],
-    subject = namestat_data[5],
+    subject = namestat_data[5]:sub(3),
     namestat = utils.vec_slice(namestat_data, 6),
     numstat = numstat_data,
   }
@@ -426,7 +426,7 @@ local incremental_fh_data = async.void(function(git_root, path_args, single_file
     args = utils.vec_join(
       "log",
       log_opt.rev_range,
-      "--pretty=format:%x00%n%H %P%n%an%n%ad%n%ar%n%s",
+      "--pretty=format:%x00%n%H %P%n%an%n%ad%n%ar%n  %s",
       "--date=raw",
       "--name-status",
       options,

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -23,8 +23,8 @@ local M = {}
 ---@type FlagValueMap
 local comp_open = arg_parser.FlagValueMap()
 comp_open:put({ "u", "untracked-files" }, { "true", "normal", "all", "false", "no" })
-comp_open:put({ "cached", "staged" }, { "true", "false" })
-comp_open:put({ "imply-local" }, { "true", "false" })
+comp_open:put({ "cached", "staged" })
+comp_open:put({ "imply-local" })
 comp_open:put({ "C" }, function(_, arg_lead)
   return vim.fn.getcompletion(arg_lead, "dir")
 end)
@@ -43,6 +43,25 @@ end)
 comp_file_history:put({ "C" }, function(_, arg_lead)
   return vim.fn.getcompletion(arg_lead, "dir")
 end)
+comp_file_history:put({ "--follow" })
+comp_file_history:put({ "--first-parent" })
+comp_file_history:put({ "--show-pulls" })
+comp_file_history:put({ "--all" })
+comp_file_history:put({ "--merges" })
+comp_file_history:put({ "--no-merges" })
+comp_file_history:put({ "--reverse" })
+comp_file_history:put({ "--max-count", "-n" }, {})
+comp_file_history:put({ "--diff-merges" }, {
+  "off",
+  "on",
+  "first-parent",
+  "separate",
+  "combined",
+  "dense-combined",
+  "remerge",
+})
+comp_file_history:put({ "--author" }, {})
+comp_file_history:put({ "--grep" }, {})
 
 function M.setup(user_config)
   config.setup(user_config or {})

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -46,6 +46,7 @@ end)
 comp_file_history:put({ "--follow" })
 comp_file_history:put({ "--first-parent" })
 comp_file_history:put({ "--show-pulls" })
+comp_file_history:put({ "--reflog" })
 comp_file_history:put({ "--all" })
 comp_file_history:put({ "--merges" })
 comp_file_history:put({ "--no-merges" })
@@ -142,6 +143,14 @@ function M.init()
   DiffviewGlobal.emitter:on("diff_buf_win_enter", function(_)
     vim.cmd("do User DiffviewDiffBufWinEnter")
   end)
+
+  -- Set up completion wrapper used by `vim.ui.input()`
+  vim.cmd([[
+    function! Diffview__ui_input_completion(...) abort
+      return luaeval("DiffviewGlobal.state.current_completer(
+            \ unpack(vim.fn.eval('a:000')))")
+    endfunction
+  ]])
 end
 
 function M.open(...)

--- a/lua/diffview/logger.lua
+++ b/lua/diffview/logger.lua
@@ -4,18 +4,18 @@ local Mock = require("diffview.mock").Mock
 
 ---@class Logger
 ---@field plugin string
----@field trace fun(obj: any)
----@field debug fun(obj: any)
----@field info fun(obj: any)
----@field warn fun(obj: any)
----@field error fun(obj: any)
----@field fatal fun(obj: any)
----@field s_trace fun(obj: any)
----@field s_debug fun(obj: any)
----@field s_info fun(obj: any)
----@field s_warn fun(obj: any)
----@field s_error fun(obj: any)
----@field s_fatal fun(obj: any)
+---@field trace fun(...: any)
+---@field debug fun(...: any)
+---@field info fun(...: any)
+---@field warn fun(...: any)
+---@field error fun(...: any)
+---@field fatal fun(...: any)
+---@field s_trace fun(...: any)
+---@field s_debug fun(...: any)
+---@field s_info fun(...: any)
+---@field s_warn fun(...: any)
+---@field s_error fun(...: any)
+---@field s_fatal fun(...: any)
 local logger = log.new({
   plugin = "diffview",
   highlights = false,
@@ -32,7 +32,7 @@ logger.outfile = string.format(
 
 -- Add scheduled variants of the different log methods.
 for _, kind in ipairs({ "trace", "debug", "info", "warn", "error", "fatal" }) do
-  logger["s_" .. kind] = vim.schedule_wrap(function (...)
+  logger["s_" .. kind] = vim.schedule_wrap(function(...)
     local args = vim.tbl_map(function(v)
       if type(v) == "table" and type(v.__tostring) == "function" then
         return tostring(v)
@@ -86,13 +86,13 @@ function logger.log_job(job, opt)
   end
 
   log_func(("%s[job-info] Exit code: %s"):format(context, job.code))
-  log_func(("%s[cmd] %s %s"):format(context, job.command, table.concat(args, " ")))
+  log_func(("%s     [cmd] %s %s"):format(context, job.command, table.concat(args, " ")))
 
   if not opt.no_stdout and stdout[1] then
-    log_func(context .. "[stdout] " .. table.concat(stdout, "\n"))
+    log_func(context .. "  [stdout] " .. table.concat(stdout, "\n"))
   end
   if not opt.no_stderr and stderr[1] then
-    log_func(context .. "[stderr] " .. table.concat(stderr, "\n"))
+    log_func(context .. "  [stderr] " .. table.concat(stderr, "\n"))
   end
 end
 

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -792,15 +792,28 @@ function M.input_char(prompt, opt)
   return s, raw
 end
 
-function M.input(prompt, default, completion)
-  local v = vim.fn.input({
+---@class InputSpec
+---@field default string
+---@field completion string|function
+---@field cancelreturn string
+---@field callback fun(response: string?)
+
+---@param prompt string
+---@param opt InputSpec
+function M.input(prompt, opt)
+  local completion = opt.completion
+  if type(completion) == "function" then
+    DiffviewGlobal.state.current_completer = completion
+    completion = "customlist,Diffview__ui_input_completion"
+  end
+
+  vim.ui.input({
     prompt = prompt,
-    default = default,
+    default = opt.default,
     completion = completion,
-    cancelreturn = "__INPUT_CANCELLED__",
-  })
+    cancelreturn = opt.cancelreturn or "__INPUT_CANCELLED__",
+  }, opt.callback)
   M.clear_prompt()
-  return v
 end
 
 function M.raw_key(vim_key)

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -271,7 +271,7 @@ function M.handle_job(job, opt)
   end
 
   log_func(msg)
-  log_func(("%s[cmd] %s %s"):format(context, job.command, table.concat(args, " ")))
+  log_func(("%s   [cmd] %s %s"):format(context, job.command, table.concat(args, " ")))
 
   local stderr = job:stderr_result()
   if #stderr > 0 then
@@ -329,7 +329,7 @@ function M.system_list(cmd, cwd_or_opt)
   for i = 0, max_retries do
     if i > 0 then
       logger.warn(
-        ("%sJob silently returned nothing! Retrying %d more time(s)...")
+        ("%sJob expected output, but returned nothing! Retrying %d more time(s)...")
         :format(context, max_retries - i + 1)
       )
       logger.log_job(job, { func = logger.warn, context = opt.context })
@@ -474,10 +474,28 @@ function M.tbl_clear(t)
   end
 end
 
+---Try property access.
+---@param t table
+---@param table_path string A `.` separated string of table keys.
+---@return any?
+function M.tbl_access(t, table_path)
+  local keys = vim.split(table_path, ".", { plain = true })
+  local cur = t
+
+  for _, k in ipairs(keys) do
+    cur = cur[k]
+    if not cur then
+      return nil
+    end
+  end
+
+  return cur
+end
+
 ---Create a shallow copy of a portion of a vector.
 ---@param t vector
----@param first? integer First index, inclusive
----@param last? integer Last index, inclusive
+---@param first? integer First index, inclusive. (default: 1)
+---@param last? integer Last index, inclusive. (default: `#t`)
 ---@return vector
 function M.vec_slice(t, first, last)
   local slice = {}

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -229,6 +229,7 @@ end
 ---@field fail_on_empty boolean Consider the job as failed if the code is 0 and stdout is empty.
 ---@field log_func function|string
 ---@field context string Context for the logger.
+---@field debug_opt LogJobSpec
 
 ---Handles logging of failed jobs. If the given job hasn't failed, this does nothing.
 ---@param job Job
@@ -242,6 +243,9 @@ function M.handle_job(job, opt)
   end
 
   if job.code == 0 and not empty then
+    if opt.debug_opt then
+      require("diffview.logger").log_job(job, opt.debug_opt)
+    end
     return
   end
 

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -1,3 +1,4 @@
+local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
 local Diff = require("diffview.diff").Diff
 local EditToken = require("diffview.diff").EditToken
 local Event = require("diffview.events").Event
@@ -31,6 +32,7 @@ local M = {}
 ---@field right Rev
 ---@field options DiffViewOptions
 ---@field panel FilePanel
+---@field commit_log_panel CommitLogPanel
 ---@field files FileDict
 ---@field file_idx integer
 ---@field initialized boolean
@@ -66,6 +68,9 @@ function DiffView:init(opt)
 end
 
 function DiffView:post_open()
+  self.commit_log_panel = CommitLogPanel(self.git_root, {
+    name = ("diffview://%s/log/%d/%s"):format(self.git_dir, self.tabpage, "commit_log"),
+  })
   self:init_event_listeners()
   vim.schedule(function()
     self:file_safeguard()
@@ -82,6 +87,7 @@ function DiffView:close()
   for _, file in self.files:ipairs() do
     file:destroy()
   end
+  self.commit_log_panel:destroy()
   DiffView:super().close(self)
 end
 

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -1,4 +1,3 @@
-local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
 local Event = require("diffview.events").Event
 local FileEntry = require("diffview.views.file_entry").FileEntry
 local RevType = require("diffview.git.rev").RevType
@@ -6,9 +5,6 @@ local api = vim.api
 local async = require("plenary.async")
 local git = require("diffview.git.utils")
 local utils = require("diffview.utils")
-
----@type CommitLogPanel
-local log_panel
 
 ---@param view DiffView
 return function(view)
@@ -103,14 +99,8 @@ return function(view)
         return
       end
 
-      if not log_panel then
-        log_panel = CommitLogPanel(view.git_root, {
-          name = ("diffview://%s/log/%d/%s"):format(view.git_dir, view.tabpage, "commit_log"),
-        })
-      end
-
       local rev_arg = ("%s..%s"):format(view.left.commit, view.right.commit or "HEAD")
-      log_panel:update(rev_arg)
+      view.commit_log_panel:update(rev_arg)
     end,
     toggle_stage_entry = function()
       if not (view.left.type == RevType.INDEX and view.right.type == RevType.LOCAL) then

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -39,7 +39,7 @@ local perf_update = PerfTimer("[FileHistoryPanel] update")
 ---@field raw_args string[]
 ---@field base Rev
 ---@field rev_range RevRange
----@field log_options LogOptions
+---@field log_options ConfigLogOptions
 ---@field cur_item {[1]: LogEntry, [2]: FileEntry}
 ---@field single_file boolean
 ---@field updating boolean
@@ -95,7 +95,18 @@ function FileHistoryPanel:init(parent, git_root, entries, path_args, raw_args, l
   self.cur_item = {}
   self.single_file = entries[1] and entries[1].single_file
   self.option_panel = FHOptionPanel(self)
-  self.log_options = vim.tbl_extend("force", conf.file_history_panel.log_options, log_options)
+  self.log_options = {
+    single_file = vim.tbl_extend(
+      "force",
+      conf.file_history_panel.log_options.single_file,
+      log_options
+    ),
+    multiple_files = vim.tbl_extend(
+      "force",
+      conf.file_history_panel.log_options.multiple_files,
+      log_options
+    ),
+  }
 
   self:on_autocmd("BufNew", {
     callback = function()
@@ -476,6 +487,15 @@ function FileHistoryPanel:render()
   require("diffview.views.file_history.render").file_history_panel(self)
   perf_render:time()
   logger.lvl(10).s_debug(perf_render)
+end
+
+---@return LogOptions
+function FileHistoryPanel:get_log_options()
+  if self.single_file then
+    return self.log_options.single_file
+  else
+    return self.log_options.multiple_files
+  end
 end
 
 M.FileHistoryPanel = FileHistoryPanel

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -1,3 +1,4 @@
+local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
 local Event = require("diffview.events").Event
 local EventEmitter = require("diffview.events").EventEmitter
 local FileEntry = require("diffview.views.file_entry").FileEntry
@@ -16,6 +17,7 @@ local M = {}
 ---@field git_root string
 ---@field git_dir string
 ---@field panel FileHistoryPanel
+---@field commit_log_panel CommitLogPanel
 ---@field path_args string[]
 ---@field raw_args string[]
 ---@field rev_arg string?
@@ -48,6 +50,9 @@ function FileHistoryView:init(opt)
 end
 
 function FileHistoryView:post_open()
+  self.commit_log_panel = CommitLogPanel(self.git_root, {
+    name = ("diffview://%s/log/%d/%s"):format(self.git_dir, self.tabpage, "commit_log"),
+  })
   self:init_event_listeners()
   vim.schedule(function()
     self:file_safeguard()
@@ -70,6 +75,7 @@ function FileHistoryView:close()
   for _, entry in ipairs(self.panel.entries or {}) do
     entry:destroy()
   end
+  self.commit_log_panel:destroy()
   FileHistoryView:super().close(self)
 end
 

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -20,7 +20,6 @@ local M = {}
 ---@field commit_log_panel CommitLogPanel
 ---@field path_args string[]
 ---@field raw_args string[]
----@field rev_arg string?
 local FileHistoryView = oop.create_class("FileHistoryView", StandardView)
 
 function FileHistoryView:init(opt)
@@ -34,7 +33,6 @@ function FileHistoryView:init(opt)
   self.git_dir = git.git_dir(self.git_root)
   self.path_args = opt.path_args
   self.raw_args = opt.raw_args
-  self.rev_arg = opt.rev_arg
   self.panel = FileHistoryPanel(
     self,
     self.git_root,
@@ -42,10 +40,7 @@ function FileHistoryView:init(opt)
     self.path_args,
     self.raw_args,
     opt.log_options,
-    {
-      base = opt.base,
-      rev_arg = opt.rev_arg,
-    }
+    { base = opt.base, }
   )
 end
 

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -1,13 +1,9 @@
-local CommitLogPanel = require("diffview.ui.panels.commit_log_panel").CommitLogPanel
 local DiffView = require("diffview.views.diff.diff_view").DiffView
 local FileEntry = require("diffview.views.file_entry").FileEntry
 local api = vim.api
 local git = require("diffview.git.utils")
 local lib = require("diffview.lib")
 local utils = require("diffview.utils")
-
----@type CommitLogPanel
-local log_panel
 
 ---@param view FileHistoryView
 return function(view)
@@ -116,12 +112,7 @@ return function(view)
     open_commit_log = function()
       local file = view:infer_cur_file()
       if file then
-        if not log_panel then
-          log_panel = CommitLogPanel(view.git_root, {
-            name = ("diffview://%s/log/%d/%s"):format(view.git_dir, view.tabpage, "commit_log"),
-          })
-        end
-        log_panel:update(file.right.commit .. "^!")
+        view.commit_log_panel:update(file.right.commit .. "^!")
       end
     end,
     focus_files = function()

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -108,7 +108,7 @@ function FHOptionPanel:init(parent)
     ---@type PanelSplitSpec
     config = {
       position = "bottom",
-      height = 17,
+      height = #FHOptionPanel.flags.switches + #FHOptionPanel.flags.options + 4,
     },
     bufname = "DiffviewFHOptionPanel",
   })

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -52,7 +52,7 @@ FHOptionPanel.flags = {
   },
   ---@type FlagOption[]
   options = {
-    { "=n", "--max-count=", "Limit number of commits" },
+    { "=n", "--max-count=", "Limit the number of commits" },
     {
       "=d", "--diff-merges=", "Determines how merge commits are treated",
       select = {
@@ -93,7 +93,7 @@ function FHOptionPanel:init(parent)
 
   ---@param option_name string
   self.emitter:on("set_option", function(option_name)
-    local log_options = self.parent.log_options
+    local log_options = self.parent:get_log_options()
 
     if FHOptionPanel.flags.switches[option_name] then
       log_options[option_name] = not log_options[option_name]
@@ -141,7 +141,7 @@ function FHOptionPanel:init(parent)
 
   self:on_autocmd("WinClosed", {
     callback = function()
-      if not vim.deep_equal(self.option_state, self.parent.log_options) then
+      if not vim.deep_equal(self.option_state, self.parent:get_log_options()) then
         vim.schedule(function ()
           self.option_state = nil
           self.winid = nil
@@ -159,7 +159,7 @@ end
 ---@Override
 function FHOptionPanel:open()
   FHOptionPanel:super().open(self)
-  self.option_state = utils.tbl_deep_clone(self.parent.log_options)
+  self.option_state = utils.tbl_deep_clone(self.parent:get_log_options())
 end
 
 function FHOptionPanel:setup_buffer()

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -144,6 +144,9 @@ local function render_entries(parent, entries, updating)
 
     offset = #s + 1
     local subject = utils.str_shorten(entry.commit.subject, 72)
+    if subject == "" then
+      subject = "[empty message]"
+    end
     comp:add_hl("DiffviewFilePanelFileName", line_idx, offset, offset + #subject)
     s = s .. " " .. subject
 

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -198,6 +198,7 @@ return {
     end
 
     local comp = panel.components.header.comp
+    local log_options = panel:get_log_options()
     local cached = cache[panel]
     local line_idx = 0
     local s
@@ -237,12 +238,12 @@ return {
       comp:add_line(s .. paths)
     end
 
-    if panel.rev_arg then
+    if log_options.rev_range then
       line_idx = line_idx + 1
-      s = "Range: "
+      s = "Revision range: "
       comp:add_hl("DiffviewFilePanelPath", line_idx, 0, #s)
       offset = #s
-      s = s .. panel.rev_arg
+      s = s .. log_options.rev_range
       comp:add_hl("DiffviewFilePanelFileName", line_idx, offset, offset + #s)
       comp:add_line(s)
     end
@@ -308,7 +309,7 @@ return {
       local enabled = log_options[comp.context[1]]
 
       s = " " .. option[1] .. " "
-      comp:add_hl("DiffviewDim1", 0, 0, #s)
+      comp:add_hl("DiffviewSecondary", 0, 0, #s)
 
       offset = #s
       comp:add_hl("DiffviewFilePanelFileName", 0, offset, offset + #option[3])
@@ -342,7 +343,7 @@ return {
       local value = log_options[comp.context[1]] or ""
 
       s = " " .. option[1] .. " "
-      comp:add_hl("DiffviewDim1", 0, 0, #s)
+      comp:add_hl("DiffviewSecondary", 0, 0, #s)
 
       offset = #s
       comp:add_hl("DiffviewFilePanelFileName", 0, offset, offset + #option[3])

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -205,10 +205,10 @@ return {
     -- root path
     comp:add_hl("DiffviewFilePanelRootPath", line_idx, 0, #cached.root_path)
     comp:add_line(cached.root_path)
-    line_idx = line_idx + 1
 
     local offset
     if panel.single_file then
+      line_idx = line_idx + 1
       if #panel.entries > 0 then
         local file = panel.entries[1].files[1]
 
@@ -227,7 +227,8 @@ return {
         s = icon .. file.path
         comp:add_line(s)
       end
-    else
+    elseif #cached.args > 0 then
+      line_idx = line_idx + 1
       s = "Showing history for: "
       comp:add_hl("DiffviewFilePanelPath", line_idx, 0, #s)
       offset = #s
@@ -294,6 +295,7 @@ return {
     local comp = panel.components.switches.title.comp
     local line_idx = 0
     local offset
+    local log_options = panel.parent:get_log_options()
 
     local s = "Switches"
     comp:add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
@@ -303,7 +305,7 @@ return {
       ---@type RenderComponent
       comp = item.comp
       local option = comp.context[2]
-      local enabled = panel.parent.log_options[comp.context[1]]
+      local enabled = log_options[comp.context[1]]
 
       s = " " .. option[1] .. " "
       comp:add_hl("DiffviewDim1", 0, 0, #s)
@@ -337,7 +339,7 @@ return {
       ---@type RenderComponent
       comp = item.comp
       local option = comp.context[2]
-      local value = panel.parent.log_options[comp.context[1]] or ""
+      local value = log_options[comp.context[1]] or ""
 
       s = " " .. option[1] .. " "
       comp:add_hl("DiffviewDim1", 0, 0, #s)

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -71,9 +71,20 @@ end
 local function render_entries(parent, entries, updating)
   local c = config.get_config()
   local max_num_files = -1
+  local max_len_stats = 7
   for _, entry in ipairs(entries) do
     if #entry.files > max_num_files then
       max_num_files = #entry.files
+    end
+    if entry.stats then
+      local adds = tostring(entry.stats.additions)
+      local dels = tostring(entry.stats.deletions)
+      local l = 7
+      local w = l - (#adds + #dels)
+      if w < 1 then
+        l = (#adds + #dels) - ((#adds + #dels) % 2) + 2
+      end
+      max_len_stats = l > max_len_stats and l or max_len_stats
     end
   end
 
@@ -108,12 +119,7 @@ local function render_entries(parent, entries, updating)
     if entry.stats then
       local adds = tostring(entry.stats.additions)
       local dels = tostring(entry.stats.deletions)
-      local l = 7
-      local w = l - (#adds + #dels)
-      if w < 1 then
-        l = (#adds + #dels) - ((#adds + #dels) % 2) + 2
-        w = l - (#adds + #dels)
-      end
+      local w = max_len_stats - (#adds + #dels)
 
       comp:add_hl("DiffviewNonText", line_idx, #s + 1, #s + 2)
       s = s .. " | "


### PR DESCRIPTION
This makes all the options passed to git-log configurable, adds additional options to make the file history view more useable as a general git-log porcelain interface, and sets better defaults.

### `++rev-range`

You can now change the target revision range from inside the file history view, as opposed to before when you would have to specify the rev range with the `--range` command option. The option is called `++rev-range` in the option panel, and it supports rev completion.

Further, you can now pass all the log options directly to the `:DiffviewFileHistory` command as flag options, to override the default log options defined in the config. Example:

```
:DiffviewFileHistory -n128 --reflog --first-parent --grep=foobar
```

Additional new log options:

- `--first-parent`
- `--reflog`
- `--show-pulls`
- `--diff-merges`

Please do open an issue if there are git-log options you wish to see implemented. `-L<start>,<end>, -L:<funcname>` is currently planned (#114).

## Breaking changes

Calling `:DiffviewFileHistory` with no args would previously target the file in the current buffer. This has now been changed to instead target the top-level of the working tree. This was changed because with how it worked before, there was effectively no way to get the file history equivalent of running `git log` with no path args. If your cwd was some subdirectory of the working tree, and you wanted the full file history of the tree, you would have to manually type out the path to the top-level. On the contrary, getting the history for the current file is always as simple as just using `%`, which expands to the current file name.

### **To get the file history for the current file like before, simply run: `:DiffviewFileHistory %`.**

The config for log options has changed. The table is now divided into the sub-tables `single_file`, and `multi_file`. This allows you to define different default log options for history targeting singular files, and history targeting multiple paths, and/or directories. To update your config, just move all your log options into the new table keys `single_file` and `multi_file`:

Before:

```lua
require("diffview").setup({
  -- ...
  file_history_panel = {
    log_options = {
      max_count = 512,
      follow = true,
    },
  },
})
```

After:

```lua
require("diffview").setup({
  -- ...
  file_history_panel = {
    log_options = {
      single_file = {
        max_count = 512,
        follow = true,
      },
      multi_file = {
        max_count = 128,
        -- follow = false   -- `follow` only applies to single-file history
      },
    },
  },
})
```

**You only need to define the options you want to change from the defaults.** To find all the available log options, see `:h diffview.git.LogOptions`.

## Other changes:

- feat(file-history): Use `vim.ui.input()` and `vim.ui.select()` in the option
  panel to request input from the user.
- fix(file-history): Handle empty commit messages.
- fix: Fixed bug that made the commit log panel only work for a single working
  tree.
- feat(file-history): The git stats in the file panel are now aligned more
  nicely when there are commits with large change numbers.
- fix: Ensure libuv timer handles are released.
- docs: More detailed documentation for file history and log options.
- chore: Better error messages when the file history fails to update.
- chore: Adjusted some highlights.

Fixes #150.