### PR TITLE
chore: Add highlight group for WinSeparator.

### DIFF
--- a/lua/diffview/colors.lua
+++ b/lua/diffview/colors.lua
@@ -121,6 +121,7 @@ M.hl_links = {
   NonText = "NonText",
   CursorLine = "CursorLine",
   VertSplit = "VertSplit",
+  WinSeparator = "WinSeparator",
   SignColumn = "Normal",
   StatusLine = "StatusLine",
   StatusLineNC = "StatusLineNC",

--- a/lua/diffview/colors.lua
+++ b/lua/diffview/colors.lua
@@ -120,7 +120,6 @@ M.hl_links = {
   Normal = "Normal",
   NonText = "NonText",
   CursorLine = "CursorLine",
-  VertSplit = "VertSplit",
   WinSeparator = "WinSeparator",
   SignColumn = "Normal",
   StatusLine = "StatusLine",

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -29,7 +29,6 @@ FilePanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "EndOfBuffer:DiffviewEndOfBuffer",
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
-    "VertSplit:DiffviewVertSplit",
     "WinSeparator:DiffviewWinSeparator",
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -30,6 +30,7 @@ FilePanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
     "VertSplit:DiffviewVertSplit",
+    "WinSeparator:DiffviewWinSeparator",
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",
     "StatusLineNC:DiffviewStatuslineNC",

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -43,7 +43,6 @@ FileHistoryPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "EndOfBuffer:DiffviewEndOfBuffer",
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
-    "VertSplit:DiffviewVertSplit",
     "WinSeparator:DiffviewWinSeparator",
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",

--- a/lua/diffview/views/file_history/file_history_panel.lua
+++ b/lua/diffview/views/file_history/file_history_panel.lua
@@ -44,6 +44,7 @@ FileHistoryPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
     "VertSplit:DiffviewVertSplit",
+    "WinSeparator:DiffviewWinSeparator",
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",
     "StatusLineNC:DiffviewStatuslineNC",

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -23,7 +23,6 @@ FHOptionPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "EndOfBuffer:DiffviewEndOfBuffer",
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
-    "VertSplit:DiffviewVertSplit",
     "WinSeparator:DiffviewWinSeparator",
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -24,6 +24,7 @@ FHOptionPanel.winopts = vim.tbl_extend("force", Panel.winopts, {
     "Normal:DiffviewNormal",
     "CursorLine:DiffviewCursorLine",
     "VertSplit:DiffviewVertSplit",
+    "WinSeparator:DiffviewWinSeparator",
     "SignColumn:DiffviewNormal",
     "StatusLine:DiffviewStatusLine",
     "StatusLineNC:DiffviewStatuslineNC",


### PR DESCRIPTION
This adds the highlight group for WinSeparator, which has superseded VertSplit. This allows the border between the Diffview panel and the buffer window to be changed without changing the border between buffer windows.