### PR TITLE
feat: Configure the git command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ local actions = require("diffview.actions")
 require("diffview").setup({
   diff_binaries = false,    -- Show diffs for binaries
   enhanced_diff_hl = false, -- See ':h diffview-config-enhanced_diff_hl'
+  git_cmd = { "git" },      -- The git executable followed by default args.
   use_icons = true,         -- Requires nvim-web-devicons
   icons = {                 -- Only applies when use_icons is true.
     folder_closed = "",

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -164,8 +164,8 @@ enhanced_diff_hl                                *diffview-config-enhanced_diff_h
 git_cmd                                         *diffview-config-git_cmd*
         Type: `string[]`, Default: `{ "git" }`
 
-        This table forms the first part of the command used to run git
-        commands. The first element should be the git binary. The subsequent
+        This table forms the first part of all git commands used internally in
+        the plugin. The first element should be the git binary. The subsequent
         elements are passed as arguments.
 
 win_config                                      *diffview-config-win_config*

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -40,6 +40,7 @@ Example configuration with default settings:
     require("diffview").setup({
       diff_binaries = false,    -- Show diffs for binaries
       enhanced_diff_hl = false, -- See |diffview-config-enhanced_diff_hl|
+      git_cmd = { "git" },      -- The git executable followed by default args.
       use_icons = true,         -- Requires nvim-web-devicons
       icons = {                 -- Only applies when use_icons is true.
         folder_closed = "",
@@ -159,6 +160,13 @@ enhanced_diff_hl                                *diffview-config-enhanced_diff_h
         Enable/disable enhanced diff highlighting. When enabled, |hl-DiffAdd|
         in the left diff buffer will be highlighted as |hl-DiffDelete|, and
         the delete fill-chars will be highlighted more subtly.
+
+git_cmd                                         *diffview-config-git_cmd*
+        Type: `string[]`, Default: `{ "git" }`
+
+        This table forms the first part of the command used to run git
+        commands. The first element should be the git binary. The subsequent
+        elements are passed as arguments.
 
 win_config                                      *diffview-config-win_config*
         Type: `table | fun(): table`, Default: `{}`

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -25,6 +25,7 @@ end
 M.defaults = {
   diff_binaries = false,
   enhanced_diff_hl = false,
+  git_cmd = { "git" },
   use_icons = true,
   icons = {
     folder_closed = "",
@@ -266,6 +267,10 @@ function M.setup(user_config)
   end
 
   --#endregion
+
+  if #M._config.git_cmd == 0 then
+    M._config.git_cmd = M.defaults.git_cmd
+  end
 
   for _, name in ipairs({ "single_file", "multi_file" }) do
     local t = M._config.file_history_panel.log_options

--- a/lua/diffview/git/commit.lua
+++ b/lua/diffview/git/commit.lua
@@ -4,6 +4,8 @@ local utils = require("diffview.utils")
 
 ---@type ERevType|LazyModule
 local RevType = lazy.access("diffview.git.rev", "RevType")
+---@module "diffview.git.utils"
+local git = lazy.require("diffview.git.utils")
 
 local M = {}
 
@@ -40,8 +42,7 @@ end
 ---@param git_root string
 ---@return Commit
 function Commit.from_rev_arg(rev_arg, git_root)
-  local out, code = utils.system_list({
-    "git",
+  local out, code = git.exec_sync({
     "show",
     "--pretty=format:%H %P%n%an%n%ad%n%ar%n  %s",
     "--date=raw",

--- a/lua/diffview/git/rev.lua
+++ b/lua/diffview/git/rev.lua
@@ -1,5 +1,9 @@
-local utils = require("diffview.utils")
+local lazy = require("diffview.lazy")
 local oop = require("diffview.oop")
+
+---@module "diffview.git.utils"
+local git = lazy.require("diffview.git.utils")
+
 local M = {}
 
 ---@class RevType : EnumValue
@@ -46,7 +50,7 @@ end
 ---@param git_root? string
 ---@return Rev
 function Rev.from_name(name, git_root)
-  local out, code = utils.system_list({ "git", "rev-parse", "--revs-only", name }, git_root)
+  local out, code = git.exec_sync({ "rev-parse", "--revs-only", name }, git_root)
   if code ~= 0 then
     return
   end
@@ -57,8 +61,8 @@ end
 ---@param git_root string
 ---@return Rev
 function Rev.earliest_commit(git_root)
-  local out, code = utils.system_list({
-    "git", "rev-list", "--max-parents=0", "--first-parent", "HEAD"
+  local out, code = git.exec_sync({
+    "rev-list", "--max-parents=0", "--first-parent", "HEAD"
   }, git_root)
 
   if code ~= 0 then
@@ -86,7 +90,7 @@ function Rev:is_head(git_root)
     return false
   end
 
-  local out, code = utils.system_list({ "git", "rev-parse", "HEAD", "--" }, git_root)
+  local out, code = git.exec_sync({ "rev-parse", "HEAD", "--" }, git_root)
   if code ~= 0 or not (out[1] and out[1] ~= "") then
     return
   end

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -229,12 +229,12 @@ function M.rev_candidates(git_root, git_dir)
     )
   )
   -- stylua: ignore end
-  local revs = utils.system_list(
-    { "git", "rev-parse", "--symbolic", "--branches", "--tags", "--remotes" },
+  local revs = git.exec_sync(
+    { "rev-parse", "--symbolic", "--branches", "--tags", "--remotes" },
     { cwd = git_root, silent = true }
   )
-  local stashes = utils.system_list(
-    { "git", "stash", "list", "--pretty=format:%gd" },
+  local stashes = git.exec_sync(
+    { "stash", "list", "--pretty=format:%gd" },
     { cwd = git_root, silent = true }
   )
 

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -260,8 +260,8 @@ function M.parse_revs(git_root, rev_arg, opt)
       left, right = M.imply_local(left, right, head)
     end
   else
-    local rev_strings, code, stderr = utils.system_list(
-      { "git", "rev-parse", "--revs-only", rev_arg }, git_root
+    local rev_strings, code, stderr = git.exec_sync(
+      { "rev-parse", "--revs-only", rev_arg }, git_root
     )
     if code ~= 0 then
       utils.err(utils.vec_join(

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -111,9 +111,9 @@ return function(view)
       if item then
         local code
         if item.kind == "working" then
-          _, code = utils.system_list({ "git", "add", item.path }, view.git_root)
+          _, code = git.exec_sync({ "add", item.path }, view.git_root)
         elseif item.kind == "staged" then
-          _, code = utils.system_list({ "git", "reset", "--", item.path }, view.git_root)
+          _, code = git.exec_sync({ "reset", "--", item.path }, view.git_root)
         end
 
         if code ~= 0 then
@@ -162,7 +162,7 @@ return function(view)
       end, view.files.working)
 
       if #args > 0 then
-        local _, code = utils.system_list(utils.vec_join("git", "add", args), view.git_root)
+        local _, code = git.exec_sync({ "add", args }, view.git_root)
 
         if code ~= 0 then
           utils.err("Failed to stage files!")
@@ -174,7 +174,7 @@ return function(view)
       end
     end,
     unstage_all = function()
-      local _, code = utils.system_list({ "git", "reset" }, view.git_root)
+      local _, code = git.exec_sync({ "reset" }, view.git_root)
 
       if code ~= 0 then
         utils.err("Failed to unstage files!")


### PR DESCRIPTION
Fixes #158.

This allows you to configure the git command as well as default args used by all git jobs internally in the plugin.

```vimhelp
git_cmd                                         *diffview-config-git_cmd*
        Type: `string[]`, Default: `{ "git" }`

        This table forms the first part of all git commands used internally in
        the plugin. The first element should be the git binary. The subsequent
        elements are passed as arguments.
```