### PR TITLE
feat(file-history)!: Trace line evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,14 +281,18 @@ Additional commands for convenience:
 With a Diffview open and the default key bindings, you can cycle through changed
 files with `<tab>` and `<s-tab>` (see configuration to change the key bindings).
 
-### `:DiffviewFileHistory [paths] [options]`
+### `:[range]DiffviewFileHistory [paths] [options]`
 
 Opens a new file history view that lists all commits that affected the given
-paths. This is a porcelain interface for git-log.
+paths. This is a porcelain interface for git-log. Both `[paths]` and
+`[options]` may be specified in any order, even interchangeably.
 
-If no `[paths]` are given, defaults to the top-level of the git repository. The
+If no `[paths]` are given, defaults to the top-level of the working tree. The
 top-level will be inferred from the current buffer when possible, otherwise the
 cwd is used. Multiple `[paths]` may be provided and git pathspec is supported.
+
+If `[range]` is given, the file history view will trace the line evolution of the
+given range in the current file (for more info, see the `-L` flag in the docs).
 
 Examples:
 
@@ -299,6 +303,7 @@ Examples:
 - `:DiffviewFileHistory include/this and/this :!but/not/this`
 - `:DiffviewFileHistory --range=origin..HEAD`
 - `:DiffviewFileHistory --range=feat/example-branch`
+- `:'<,'>DiffviewFileHistory`
 
 ## Restoring Files
 

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -733,17 +733,22 @@ COMMANDS                                        *diffview-commands*
                         the initial set of files, this option does nothing.
 
                                                 *:DiffviewFileHistory*
-:DiffviewFileHistory [paths] [options]
+:[range]DiffviewFileHistory [paths] [options]
                         Opens a new file history view that lists all commits
                         that affected the given paths. This is a porcelain
-                        interface for git-log.
+                        interface for git-log. Both [paths] and [options] may
+                        be specified in any order, even interchangeably.
 
                         If no [paths] are given, defaults to the top-level of
-                        the git repository. The top-level will be inferred
-                        from the current buffer when possible, otherwise the
-                        cwd is used. Multiple [paths] may be provided and git
+                        the working tree. The top-level will be inferred from
+                        the current buffer when possible, otherwise the cwd is
+                        used. Multiple [paths] may be provided and git
                         pathspec is supported (see `:Man gitglossary(7)` for
                         information about pathspec).
+
+                        If [range] is given, the file history view will trace
+                        the line evolution of the given range in the current
+                        file (see the `-L` flag below).
 
                         From the file history panel (the panel listing the
                         commits) you can open an option panel by pressing
@@ -775,6 +780,7 @@ COMMANDS                                        *diffview-commands*
         :DiffviewFileHistory --base=LOCAL
         :DiffviewFileHistory --range=origin..HEAD
         :DiffviewFileHistory --range=feat/some-branch
+        :'<,'>DiffviewFileHistory
 <
 
     Options:~
@@ -812,6 +818,12 @@ COMMANDS                                        *diffview-commands*
 
         -n{n}, --max-count={n}
                         Limit the number of commits.
+
+        -L{start},{end}:{file}, -L:{funcname}:{file}
+                        Trace the evolution of the line range given by
+                        {start},{end}, or by the function name regex
+                        {funcname}, within the {file}. You can specify this
+                        option more than once.
 
         --diff-merges={value}
                         Determines how merge commits are treated. {value} can
@@ -1182,6 +1194,12 @@ LogOptions                                      *diffview.git.LogOptions*
 
             {max_count} (integer)
                 Limit the number of commits.
+
+            {L} (string[])
+                `{ ("<start>,<end>:<file>" | ":<funcname>:<file>")... }`
+
+                Trace the evolution of the line range given by <start>,<end>,
+                or by the function name regex <funcname>, within the <file>.
 
             {diff_merges} (string)
                 Determines how merge commits are treated. The value can be one

--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -3,6 +3,14 @@
 
 CHANGELOG
 
+                                                *diffview.changelog-169*
+
+PR: https://github.com/sindrets/diffview.nvim/pull/169
+
+The file history option panel is now able to accept multiple values separated
+by whitespace. This means that if you want to specify values with whitespace,
+you need to quote the value, or escape the whitespace with a backslash (`\`).
+
                                                 *diffview.changelog-151*
 
 PR: https://github.com/sindrets/diffview.nvim/pull/151

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -205,6 +205,25 @@ function M.parse(args)
   return ArgObject(flags, pre_args, post_args)
 end
 
+---Split the line range from an EX command arg.
+---@param arg string
+---@return string range, string command
+function M.split_ex_range(arg)
+  local idx = arg:match(".*()%A")
+  if not idx then
+    return  "", arg
+  end
+
+  local slice = arg:sub(idx or 1)
+  idx = slice:match("[^']()%a")
+
+  if idx then
+    return  arg:sub(1, (#arg - #slice) + idx - 1), slice:sub(idx)
+  end
+
+  return  arg, ""
+end
+
 ---Scan an EX command string and split it into individual args.
 ---@param cmd_line string
 ---@param cur_pos number

--- a/lua/diffview/arg_parser.lua
+++ b/lua/diffview/arg_parser.lua
@@ -305,7 +305,6 @@ function M.scan_sh_args(cmd_line, cur_pos)
 
     local char = cmd_line:sub(i, i)
     if char == "\\" then
-      arg = arg .. char
       if i < #cmd_line then
         i = i + 1
         arg = arg .. cmd_line:sub(i, i)

--- a/lua/diffview/bootstrap.lua
+++ b/lua/diffview/bootstrap.lua
@@ -89,6 +89,7 @@ _G.DiffviewGlobal = {
 
 DiffviewGlobal.emitter:on_any(function(event, args)
   local utils = require("diffview.utils")
+  require("diffview").nore_emit(event, utils.tbl_unpack(args))
   require("diffview.config").user_emitter:nore_emit(event, utils.tbl_unpack(args))
 end)
 

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -152,6 +152,7 @@ M._config = M.defaults
 ---@field no_merges boolean
 ---@field reverse boolean
 ---@field max_count integer
+---@field L string[]
 ---@field author string
 ---@field grep string
 ---@field diff_merges string
@@ -169,6 +170,7 @@ M.log_option_defaults = {
   reverse = false,
   rev_range = nil,
   max_count = 256,
+  L = {},
   diff_merges = nil,
   author = nil,
   grep = nil,

--- a/lua/diffview/git/log_entry.lua
+++ b/lua/diffview/git/log_entry.lua
@@ -29,26 +29,41 @@ end
 
 function LogEntry:update_status()
   self.status = nil
+  local missing_status = 0
+
   for _, file in ipairs(self.files) do
-    if self.status and file.status ~= self.status then
-      self.status = "M"
-      return
-    elseif self.status ~= file.status then
-      self.status = file.status
+    if not file.status then
+      missing_status = missing_status + 1
+    else
+      if self.status and file.status ~= self.status then
+        self.status = "M"
+        return
+      elseif self.status ~= file.status then
+        self.status = file.status
+      end
     end
   end
-  if not self.status then
+
+  if missing_status < #self.files and not self.status then
     self.status = "X"
   end
 end
 
 function LogEntry:update_stats()
   self.stats = { additions = 0, deletions = 0 }
+  local missing_stats = 0
+
   for _, file in ipairs(self.files) do
-    if file.stats then
+    if not file.stats then
+      missing_stats = missing_stats + 1
+    else
       self.stats.additions = self.stats.additions + file.stats.additions
       self.stats.deletions = self.stats.deletions + file.stats.deletions
     end
+  end
+
+  if missing_stats == #self.files then
+    self.stats = nil
   end
 end
 

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -378,17 +378,31 @@ function M.update_colors()
   lib.update_colors()
 end
 
-function M.emit(event_name, ...)
+local function _emit(no_recursion, event_name, ...)
   local view = lib.get_current_view()
+
   if view and not view.closing then
-    view.emitter:emit(event_name, ...)
+    local that = view.emitter
+    local fn = no_recursion and that.nore_emit or that.emit
+    fn(that, event_name, ...)
+
+    that = DiffviewGlobal.emitter
+    fn = no_recursion and that.nore_emit or that.emit
 
     if event_name == "tab_enter" then
-      DiffviewGlobal.emitter:emit("view_enter", view)
+      fn(that, "view_enter", view)
     elseif event_name == "tab_leave" then
-      DiffviewGlobal.emitter:emit("view_leave", view)
+      fn(that, "view_enter", view)
     end
   end
+end
+
+function M.emit(event_name, ...)
+  _emit(false, event_name, ...)
+end
+
+function M.nore_emit(event_name, ...)
+  _emit(true, event_name, ...)
 end
 
 M.init()

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -165,8 +165,9 @@ function M.open(...)
   end
 end
 
-function M.file_history(...)
-  local view = lib.file_history(utils.tbl_pack(...))
+---@param range? { [1]: integer, [2]: integer }
+function M.file_history(range, ...)
+  local view = lib.file_history(range, utils.tbl_pack(...))
   if view then
     view:open()
   end
@@ -199,8 +200,14 @@ end
 
 function M.completion(arg_lead, cmd_line, cur_pos)
   local args, argidx, divideridx = arg_parser.scan_ex_args(cmd_line, cur_pos)
-  if M.completers[args[1]] then
-    return M.filter_completion(arg_lead, M.completers[args[1]](args, argidx, divideridx, arg_lead))
+  local _, cmd = arg_parser.split_ex_range(args[1])
+
+  if cmd == "" then
+    cmd = args[2]
+  end
+
+  if cmd and M.completers[cmd] then
+    return M.filter_completion(arg_lead, M.completers[cmd](args, argidx, divideridx, arg_lead))
   end
 end
 

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -209,12 +209,10 @@ function M.file_history(args)
   local log_options = { rev_range = range_arg }
   for _, names in ipairs(log_flag_names) do
     local key, _ = names[1]:gsub("%-", "_")
-    local v = argo:get_flag(
-      names,
-      type(config.log_option_defaults[key]) ~= "boolean"
-        and { expect_string = true }
-        or nil
-    )
+    local v = argo:get_flag(names, {
+      expect_string = type(config.log_option_defaults[key]) ~= "boolean",
+      expect_list = names[1] == "L",
+    })
     log_options[key] = v
   end
 

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -121,7 +121,9 @@ function M.diffview_open(args)
   return v
 end
 
-function M.file_history(args)
+---@param range? { [1]: integer, [2]: integer }
+---@param args string[]
+function M.file_history(range, args)
   local default_args = config.get_config().default_args.DiffviewFileHistory
   local argo = arg_parser.parse(vim.tbl_flatten({ default_args, args }))
   local paths = {}
@@ -214,6 +216,13 @@ function M.file_history(args)
       expect_list = names[1] == "L",
     })
     log_options[key] = v
+  end
+
+  if range then
+    paths, rel_paths = {}, {}
+    log_options.L = {
+      ("%d,%d:%s"):format(range[1], range[2], pl:relative(pl:absolute(cfile), git_root))
+    }
   end
 
   local ok, opt_description = git.file_history_dry_run(git_root, paths, log_options)

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -199,6 +199,7 @@ function M.file_history(args)
     { "no-merges" },
     { "reverse" },
     { "max-count", "n" },
+    { "L" },
     { "diff-merges" },
     { "author" },
     { "grep" },

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -625,9 +625,12 @@ end
 ---@param t vector
 ---@return vector t
 function M.vec_push(t, ...)
-  for _, v in ipairs({...}) do
-    t[#t + 1] = v
+  local args = {...}
+
+  for i = 1, select("#", ...) do
+    t[#t + 1] = args[i]
   end
+
   return t
 end
 

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -231,18 +231,42 @@ function M.str_match(str, patterns)
   end
 end
 
----@param s string
----@param esc_char? string
-function M.str_quote(s, esc_char)
-  esc_char = esc_char or "\\"
-  local has_single = s:find([[']]) ~= nil
-  local has_double = s:find([["]]) ~= nil
+---@class StrQuoteSpec
+---@field esc_fmt string Format string for escaping quotes. Passed to `string.format()`.
+---@field prefer_single boolean Prefer single quotes.
+---@field only_if_whitespace boolean Only quote the string if it contains whitespace.
 
-  if has_double and not has_single then
-    return "'" .. s .. "'"
+---@param s string
+---@param opt? StrQuoteSpec
+function M.str_quote(s, opt)
+  ---@cast opt StrQuoteSpec
+  s = tostring(s)
+  opt = vim.tbl_extend("keep", opt or {}, {
+    esc_fmt = [[\%s]],
+    prefer_single = false,
+    only_if_whitespace = false,
+  })
+
+  if opt.only_if_whitespace and not s:find("%s") then
+    return s
+  end
+
+  local primary, secondary = [["]], [[']]
+  if opt.prefer_single then
+    primary, secondary = [[']], [["]]
+  end
+
+  local has_primary = s:find(primary) ~= nil
+  local has_secondary = s:find(secondary) ~= nil
+
+  if has_primary and not has_secondary then
+    return secondary .. s .. secondary
   else
-    local result, _ = s:gsub('"', esc_char .. '"')
-    return '"' .. result .. '"'
+    local esc = opt.esc_fmt:format(primary)
+    -- First un-escape already escaped quotes to avoid incorrectly applied escapes.
+    s, _ = s:gsub(vim.pesc(esc), primary)
+    s, _ = s:gsub(primary, esc)
+    return primary .. s .. primary
   end
 end
 
@@ -520,6 +544,27 @@ function M.tbl_access(t, table_path)
   end
 
   return cur
+end
+
+---Perform a map and also filter out index values that would become `nil`.
+---@param t table
+---@param func fun(value: any): any?
+---@return table
+function M.tbl_fmap(t, func)
+  local ret = {}
+
+  for key, item in pairs(t) do
+    local v = func(item)
+    if v ~= nil then
+      if type(key) == "number" then
+        table.insert(ret, v)
+      else
+        ret[key] = v
+      end
+    end
+  end
+
+  return ret
 end
 
 ---Create a shallow copy of a portion of a vector.

--- a/lua/diffview/views/file_history/file_history_view.lua
+++ b/lua/diffview/views/file_history/file_history_view.lua
@@ -61,7 +61,9 @@ function FileHistoryView:post_open()
   self.commit_log_panel = CommitLogPanel(self.git_root, {
     name = ("diffview://%s/log/%d/%s"):format(self.git_dir, self.tabpage, "commit_log"),
   })
+
   self:init_event_listeners()
+
   vim.schedule(function()
     self:file_safeguard()
     ---@diagnostic disable-next-line: unused-local

--- a/lua/diffview/views/file_history/listeners.lua
+++ b/lua/diffview/views/file_history/listeners.lua
@@ -32,6 +32,33 @@ return function(view)
         end
       end
     end,
+    diff_buf_read = function(bufid)
+      -- Set the cursor at the beginning of the -L range if possible.
+
+      local log_options = view.panel:get_log_options()
+      local cur = view.panel:cur_file()
+
+      if log_options.L[1] and bufid == cur.right_bufid then
+        for _, value in ipairs(log_options.L) do
+          local l1, lpath = value:match("^(%d+),.*:(.*)")
+
+          if l1 then
+            l1 = tonumber(l1)
+            lpath = utils.path:chain(lpath)
+                :normalize({ cwd = view.git_root, absolute = true })
+                :relative(view.git_root)
+                :get()
+
+            print(l1, lpath)
+            if lpath == cur.path then
+              vim.fn.cursor(l1, 1)
+              vim.cmd("norm! zt")
+              break
+            end
+          end
+        end
+      end
+    end,
     open_in_diffview = function()
       if view.panel:is_focused() then
         local item = view.panel:get_item_at_cursor()

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -192,7 +192,7 @@ function FHOptionPanel:init(parent)
     local log_options = self.parent:get_log_options()
 
     if FHOptionPanel.flags.switches[option_name] then
-      log_options[option_name] = not log_options[option_name]
+      self:_set_option(option_name, not log_options[option_name])
       self:render()
       self:redraw()
 
@@ -212,7 +212,7 @@ function FHOptionPanel:init(parent)
           end,
         }, function(choice)
           if choice then
-            log_options[option_name] = choice
+            self:_set_option(option_name, choice)
           end
 
           self:render()
@@ -244,7 +244,7 @@ function FHOptionPanel:init(parent)
                 end
               end
 
-              log_options[option_name] = response
+              self:_set_option(option_name, response)
             end
 
             self:render()
@@ -279,6 +279,11 @@ function FHOptionPanel:init(parent)
       end
     end,
   })
+end
+
+function FHOptionPanel:_set_option(name, value)
+  self.parent.log_options.single_file[name] = value
+  self.parent.log_options.multi_file[name] = value
 end
 
 ---@Override

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -78,7 +78,6 @@ FHOptionPanel.flags = {
       end,
     },
     { "=n", "--max-count=", "Limit the number of commits" },
-    -- TODO: Add this as a flag option to :DiffviewFileHistory
     {
       "=L", "-L", "Trace line evolution",
       prompt_label = "(Accepts multiple values)",
@@ -93,10 +92,11 @@ FHOptionPanel.flags = {
           if v == "-L" then
             -- Filter out empty flag options
             return nil
-          elseif not v:match("^-L") then
-            -- Prepend the flag if it wasn't specified by the user.
-            v = "-L" .. v
+          elseif v:match("^-L") then
+            -- Remove the flag name
+            return v:sub(3)
           end
+
           return v
         end)
       end,
@@ -110,6 +110,10 @@ FHOptionPanel.flags = {
 
         -- Render a string of quoted args
         return false, table.concat(vim.tbl_map(function(v)
+          if not v:match("^-L") then
+            -- Prepend the flag if it wasn't specified by the user.
+            v = "-L" .. v
+          end
           return utils.str_quote(v, { only_if_whitespace = true })
         end, value), " ")
       end,

--- a/lua/diffview/views/file_history/option_panel.lua
+++ b/lua/diffview/views/file_history/option_panel.lua
@@ -83,6 +83,11 @@ FHOptionPanel.flags = {
       "=L", "-L", "Trace line evolution",
       prompt_label = "(Accepts multiple values)",
       prompt_fmt = "${label} ",
+      completion = function(_)
+        return function(arg_lead, _, _)
+          return diffview.line_trace_completion(arg_lead)
+        end
+      end,
       transform = function(values)
         return utils.tbl_fmap(values, function(v)
           if v == "-L" then

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -140,26 +140,26 @@ local function render_entries(parent, entries, updating)
         offset + #adds + w,
         offset + #adds + w + #dels
       )
-      s = s .. adds .. string.rep(" ", w) .. dels .. " |"
-      comp:add_hl("DiffviewNonText", line_idx, #s - 1, #s)
+      s = s .. adds .. string.rep(" ", w) .. dels .. " | "
+      comp:add_hl("DiffviewNonText", line_idx, #s - 2, #s)
     end
 
-    offset = #s + 1
+    offset = #s
     if entry.commit.hash then
       local hash = entry.commit.hash:sub(1, 8)
       comp:add_hl("DiffviewSecondary", line_idx, offset, offset + #hash)
-      s = s .. " " .. hash
+      s = s .. hash .. " "
     end
 
-    offset = #s + 1
+    offset = #s
     local subject = utils.str_shorten(entry.commit.subject, 72)
     if subject == "" then
       subject = "[empty message]"
     end
     comp:add_hl("DiffviewFilePanelFileName", line_idx, offset, offset + #subject)
-    s = s .. " " .. subject
+    s = s .. subject .. " "
 
-    offset = #s + 1
+    offset = #s
     if entry.commit then
       -- 3 months
       local date = (
@@ -169,7 +169,7 @@ local function render_entries(parent, entries, updating)
         )
       local info = entry.commit.author .. ", " .. date
       comp:add_hl("DiffviewFilePanelPath", line_idx, offset, offset + #info)
-      s = s .. " " .. info
+      s = s .. info
     end
 
     comp:add_line(s)
@@ -250,7 +250,7 @@ return {
       comp:add_line(s .. paths)
     end
 
-    if log_options.rev_range then
+    if log_options.rev_range and log_options.rev_range ~= "" then
       line_idx = line_idx + 1
       s = "Revision range: "
       comp:add_hl("DiffviewFilePanelPath", line_idx, 0, #s)

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -342,6 +342,7 @@ return {
     for _, item in ipairs(panel.components.options.items) do
       ---@type RenderComponent
       comp = item.comp
+      ---@type FlagOption
       local option = comp.context[2]
       local value = log_options[comp.context[1]] or ""
 
@@ -353,14 +354,14 @@ return {
       s = s .. option[3] .. " ("
 
       offset = #s
-      local flag = option[2] .. value
+      local empty, display_value = option:render_value(value)
       comp:add_hl(
-        value ~= "" and "DiffviewFilePanelCounter" or "DiffviewDim1",
+        not empty and "DiffviewFilePanelCounter" or "DiffviewDim1",
         0,
         offset,
-        offset + #flag
+        offset + #display_value
       )
-      s = s .. flag
+      s = s .. display_value
 
       offset = #s
       comp:add_hl("DiffviewFilePanelFileName", 0, offset, offset + 1)

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -22,10 +22,14 @@ local function render_files(comp, files)
       s = "│   "
     end
     comp:add_hl("DiffviewNonText", line_idx, 0, #s)
+    local offset
 
-    local offset = #s
-    comp:add_hl(renderer.get_git_hl(file.status), line_idx, offset, offset + 1)
-    s = s .. file.status .. " "
+    if file.status then
+      offset = #s
+      comp:add_hl(renderer.get_git_hl(file.status), line_idx, offset, offset + 1)
+      s = s .. file.status .. " "
+    end
+
     offset = #s
     local icon = renderer.get_file_icon(file.basename, file.extension, comp, line_idx, offset)
     offset = offset + #icon
@@ -103,9 +107,11 @@ local function render_entries(parent, entries, updating)
       s = (entry.folded and c.signs.fold_closed or c.signs.fold_open) .. " "
     end
 
-    offset = #s
-    comp:add_hl(renderer.get_git_hl(entry.status), line_idx, offset, offset + 1)
-    s = s .. entry.status
+    if entry.status then
+      offset = #s
+      comp:add_hl(renderer.get_git_hl(entry.status), line_idx, offset, offset + 1)
+      s = s .. entry.status
+    end
 
     if not entry.single_file then
       offset = #s

--- a/lua/diffview/views/file_history/render.lua
+++ b/lua/diffview/views/file_history/render.lua
@@ -76,10 +76,12 @@ local function render_entries(parent, entries, updating)
   local c = config.get_config()
   local max_num_files = -1
   local max_len_stats = 7
+
   for _, entry in ipairs(entries) do
     if #entry.files > max_num_files then
       max_num_files = #entry.files
     end
+
     if entry.stats then
       local adds = tostring(entry.stats.additions)
       local dels = tostring(entry.stats.deletions)
@@ -96,12 +98,13 @@ local function render_entries(parent, entries, updating)
     if i > #parent or (updating and i > 128) then
       break
     end
+
     local entry_struct = parent[i]
     local line_idx = 0
     local offset = 0
-
     local comp = entry_struct.commit.comp
     local s = ""
+
     if not entry.single_file then
       comp:add_hl("CursorLineNr", line_idx, 0, 3)
       s = (entry.folded and c.signs.fold_closed or c.signs.fold_open) .. " "

--- a/plugin/diffview.lua
+++ b/plugin/diffview.lua
@@ -22,21 +22,33 @@ end
 command("DiffviewOpen", function(state)
   diffview.open(unpack(state.fargs))
 end, { nargs = "*", complete = completion })
+
 command("DiffviewFileHistory", function(state)
-  diffview.file_history(unpack(state.fargs))
-end, { nargs = "*", complete = completion })
+  local range
+
+  if state.range > 0 then
+    range = { state.line1, state.line2 }
+  end
+
+  diffview.file_history(range, unpack(state.fargs))
+end, { nargs = "*", complete = completion, range = true })
+
 command("DiffviewClose", function()
   diffview.close()
 end, { nargs = 0, bang = true })
+
 command("DiffviewFocusFiles", function()
   diffview.emit("focus_files")
 end, { nargs = 0, bang = true })
+
 command("DiffviewToggleFiles", function()
   diffview.emit("toggle_files")
 end, { nargs = 0, bang = true })
+
 command("DiffviewRefresh", function()
   diffview.emit("refresh_files")
 end, { nargs = 0, bang = true })
+
 command("DiffviewLog", function()
   vim.cmd(("sp %s | norm! G"):format(
     vim.fn.fnameescape(require("diffview.logger").outfile)


### PR DESCRIPTION
Resolves #114.

This implements git-log's `-L` flag, which lets you trace the evolution of a given line range.

```vimhelp
        -L{start},{end}:{file}, -L:{funcname}:{file}
                        Trace the evolution of the line range given by
                        {start},{end}, or by the function name regex
                        {funcname}, within the {file}. You can specify this
                        option more than once.
```

## Usage

There are multiple ways of invoking line tracing. One way is to pass it as a flag option to `:DiffviewFileHistory`. You may specify this option more than once:

```
:DiffviewFileHistory -L300,500:some/example/file -L:some\ func:other/example/file
```

Another way is to specify an EX command range. This way, the file history will trace the line evolution of the given range in the current file:

```vim
" Trace the line evolution of the visual selection in the current file.
:'<,'>DiffviewFileHistory
```

The final way of invoking line tracing is to set the `-L` flag from the file history option panel (press `g!` in the file history panel).

## Notes

While showing history for line tracing, the file history panel won't show any stats, nor git status symbols for any of the listed commits. This is due to the fact that git-log with the `-L` flag is incompatible with any diff format other than `--patch`.

## Breaking changes

The file history option panel is now able to accept multiple values separated by whitespace. This means that if you want to specify values with whitespace, you need to quote the value, or escape the whitespace with a backslash (`\`).
