### PR TITLE
fix: avoid crash when closing the tab while still updating

### DIFF
--- a/lua/diffview/scene/views/file_history/file_history_panel.lua
+++ b/lua/diffview/scene/views/file_history/file_history_panel.lua
@@ -211,7 +211,11 @@ function FileHistoryPanel:update_entries(callback)
         -- The parent view has closed: shutdown git jobs and clean up.
         finalizer()
         update:close()
-        vim.schedule(function() self.option_panel:sync() end)
+        vim.schedule(function()
+          if self.option_panel then
+            self.option_panel:sync()
+          end
+        end)
         callback(nil, JobStatus.KILLED)
         return
       end


### PR DESCRIPTION
When diffview's tab is closed while the commit list is still updating (update can take a few seconds for big repositories), we get an error:

```
Error executing vim.schedule lua callback: ...diffview/scene/views/file_history/file_history_panel.lua:214: attempt to index field 'option_panel' (a nil value)
stack traceback:
        ...diffview/scene/views/file_history/file_history_panel.lua:214: in function <...diffview/scene/views/file_history/file_history_panel.lua:214>
```