### PR TITLE
fix: Regression in finding top-level

### DIFF
--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -90,11 +90,14 @@ end
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
-  local out, code = utils.system_list(vim.tbl_flatten({
-    config.get_config().git_cmd,
-    { "rev-parse", "--path-format=absolute", "--show-toplevel" },
-    path
-  }))
+  local out, code = utils.system_list(
+    vim.tbl_flatten({
+      config.get_config().git_cmd,
+      { "rev-parse", "--path-format=absolute", "--show-toplevel" },
+    }),
+    { cwd = path }
+  )
+
   if code ~= 0 then
     return nil
   end


### PR DESCRIPTION
`path` should be put in `cwd`, otherwise got "Not a repo" error when the file was in another git repo.