### PR TITLE
feat(file-history): Add git-pickaxe options.

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -226,12 +226,20 @@ COMMANDS                                        *diffview-commands*
 
         --author={pattern}
                         Limit the commits output to ones with author/committer
-                        header lines that match the specified pattern (regular
-                        expression).
+                        header lines that match the specified {pattern}
+                        (regular expression).
 
         --grep={pattern}
                         Limit the commits output to ones with log message that
-                        matches the specified pattern (regular expression).
+                        matches the specified {pattern} (regular expression).
+
+        -G{pattern}     Look for differences whose patch text contains
+                        added/removed lines that match {pattern} (extended
+                        regular expression).
+
+        -S{pattern}     Look for differences that change the number of
+                        occurences of the specified {pattern} (extended
+                        regular expression) in a file.
 
                                                 *:DiffviewClose*
 :DiffviewClose          Close the active Diffview.
@@ -1347,6 +1355,16 @@ LogOptions                                      *diffview.git.LogOptions*
             {grep} (string)
                 Limit the commits output to ones with log message that matches
                 the specified pattern (regular expression).
+
+            {G} (string)
+                Look for differences whose patch text contains added/removed
+                lines that match the specified pattern (extended regular
+                expression).
+
+            {S} (string)
+                Look for differences that change the number of occurences of
+                the specified pattern (extended regular expression) in a
+                file.
 
 
  vim:tw=78:ts=8:ft=help:norl:

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -208,6 +208,8 @@ M._config = M.defaults
 ---@field L string[]
 ---@field author string
 ---@field grep string
+---@field G string
+---@field S string
 ---@field diff_merges string
 ---@field rev_range string
 ---@field base string
@@ -230,6 +232,8 @@ M.log_option_defaults = {
   diff_merges = nil,
   author = nil,
   grep = nil,
+  G = nil,
+  S = nil,
   path_args = {},
 }
 


### PR DESCRIPTION
(resolves #244)

This adds the git-pickaxe options to file history. Git-pickaxe allows you to filter commits to the subset that has patch text matching a given pattern (regex). These options are available both as flag options passed to `:DiffviewFileHistory` and through the file history option panel.

```vimhelp
                                                *:DiffviewFileHistory*
:[range]DiffviewFileHistory [paths] [options]

    ...

    Options:~

        ...

        -G{pattern}     Look for differences whose patch text contains
                        added/removed lines that match {pattern} (extended
                        regular expression).

        -S{pattern}     Look for differences that change the number of
                        occurences of the specified {pattern} (extended
                        regular expression) in a file.

```