### PR TITLE
feat: Allow enhanced diff highlight customization

### DIFF
--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -81,14 +81,20 @@ function StandardView:init_layout()
 end
 
 function StandardView:post_layout()
-  if config.get_config().enhanced_diff_hl then
-    self.winopts.diff2.a.winhl = {
-      "DiffAdd:DiffviewDiffAddAsDelete",
-      "DiffDelete:DiffviewDiffDelete",
-    }
-    self.winopts.diff2.b.winhl = {
-      "DiffDelete:DiffviewDiffDelete",
-    }
+  local enhanced_diff_hl = config.get_config().enhanced_diff_hl
+  if enhanced_diff_hl then
+    if (type(enhanced_diff_hl) == "table") then
+      self.winopts.diff2.a.winhl = enhanced_diff_hl.a
+      self.winopts.diff2.b.winhl = enhanced_diff_hl.b
+    else
+      self.winopts.diff2.a.winhl = {
+        "DiffAdd:DiffviewDiffAddAsDelete",
+        "DiffDelete:DiffviewDiffDelete",
+      }
+      self.winopts.diff2.b.winhl = {
+        "DiffDelete:DiffviewDiffDelete",
+      }
+    end
   end
 end
 


### PR DESCRIPTION
Hey! I really enjoy using this plugin and like how `enhanced_diff_hl` looks. The idea that we can apply different highlight groups to different windows blew my mind. 
So I want to take it even further and allow user customization by allowing `enhanced_diff_hl` be an object. 

What do you think about it? 

I'll add this feature to the docs if you would like to merge it. 
 
The config will look like this:
```
require("diffview").setup({
  enhanced_diff_hl = {
    a = {
      "DiffAdd:DiffviewDiffAddAsDelete",
      "DiffDelete:DiffviewDiffDelete",
      "DiffChange:DiffviewDiffChangeAsDelete",
      "DiffText:DiffviewDiffTextRed",
    },
    b = {
      "DiffDelete:DiffviewDiffDelete",
      "DiffChange:DiffviewDiffChangeAsAdd",
      "DiffText:DiffviewDiffTextGreen",
    }
  }
 })
```