### PR TITLE
feat: Stage individual hunks by editing index buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Additional commands for convenience:
 With a Diffview open and the default key bindings, you can cycle through changed
 files with `<tab>` and `<s-tab>` (see configuration to change the key bindings).
 
+#### Staging
+
+You can stage individual hunks by editing any buffer that represents the index
+(after running `:DiffviewOpen` with no `[git-rev]` the entries under "Changes"
+will have the index buffer on the left side, and the entries under "Staged
+changes" will have it on the right side). Once you write to an index buffer the
+index will be updated.
+
 ### `:[range]DiffviewFileHistory [paths] [options]`
 
 Opens a new file history view that lists all commits that affected the given

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -55,6 +55,14 @@ COMMANDS                                        *diffview-commands*
             :DiffviewOpen HEAD~2 -- lua/diffview plugin
             :DiffviewOpen d4a7b0d -uno
 <
+
+                                                *diffview-staging*
+        You can stage individual hunks by editing any buffer that represents
+        the index (after running `:DiffviewOpen` with no [git-rev] the entries
+        under "Changes" will have the index buffer on the left side, and the
+        entries under "Staged changes" will have it on the right side). Once
+        you write to an index buffer the index will be updated.
+
                                                 *diffview-merge-tool*
         If you call `:DiffviewOpen` during a merge or a rebase, the view will
         list the conflicted files in their own section. When opening a
@@ -98,7 +106,7 @@ COMMANDS                                        *diffview-commands*
         layouts. To configure a different default layout, see
         |diffview-config-view.x.layout|.
 
-    Options:~
+    Options: ~
         -u[value], --untracked-files[={value}]
                         Specify whether or not to show untracked files. If
                         flag is given without value; defaults to `true`.
@@ -171,7 +179,7 @@ COMMANDS                                        *diffview-commands*
             :'<,'>DiffviewFileHistory
 <
 
-    Options:~
+    Options: ~
         --base={git-rev}
                         Specify a base git rev from which the right side of
                         the diff will be created. Use the special value
@@ -506,7 +514,7 @@ log_options                                     *diffview-config-log_options*
         to define different default log options for history targeting singular
         files, and history targeting multiple paths, and/or directories.
 
-        Fields:~
+        Fields: ~
             {single_file} (`LogOptions`)
                 See |diffview.git.LogOptions|.
 
@@ -535,34 +543,34 @@ hooks                                           *diffview-config-hooks*
         Diffview. The hook events are also available as User autocommands. See
         |diffview-user-autocmds| for more details.
 
-        Available Events:~
+        Available Events: ~
             {view_opened} (`fun(view: View)`)
                 Emitted after a new view has been opened. It's called after
                 initializing the layout in the new tabpage (all windows are
                 ready).
 
-                Callback Parameters:~
+                Callback Parameters: ~
                     {view} (`View`)
                         The `View` instance that was opened.
 
             {view_closed} (`fun(view: View)`)
                 Emitted after closing a view.
 
-                Callback Parameters:~
+                Callback Parameters: ~
                     {view} (`View`)
                         The `View` instance that was closed.
 
             {view_enter} (`fun(view: View)`)
                 Emitted just after entering the tabpage of a view.
 
-                Callback Parameters:~
+                Callback Parameters: ~
                     {view} (`View`)
                         The `View` instance that was entered.
 
             {view_leave} (`fun(view: View)`)
                 Emitted just before leaving the tabpage of a view.
 
-                Callback Parameters:~
+                Callback Parameters: ~
                     {view} (`View`)
                         The `View` instance that's about to be left.
 
@@ -577,7 +585,7 @@ hooks                                           *diffview-config-hooks*
                 that |:setlocal| will apply settings to the relevant buffer /
                 window.
 
-                Callback Parameters:~
+                Callback Parameters: ~
                     {bufnr} (`integer`)
                         The buffer number of the new buffer.
 
@@ -589,7 +597,7 @@ hooks                                           *diffview-config-hooks*
                 that |:setlocal| will apply settings to the relevant buffer /
                 window.
 
-                Callback Parameters:~
+                Callback Parameters: ~
                     {bufnr} (`integer`)
                         The buffer number of the new buffer.
                     {winid} (`integer`)
@@ -665,7 +673,7 @@ keymaps                                         *diffview-config-keymaps*
 <
 
                                                 *diffview-actions*
-Actions~
+Actions ~
 
         Actions are key-mappable functions. You can access an action through
         the config module: >
@@ -680,7 +688,7 @@ Actions~
         Following are the different contexts described alongside possible
         subjects, upon which actions called from their context, will act on.
 
-        Contexts:~
+        Contexts: ~
             {diff_view}
                 The windows containing the diff buffers in a Diffview.
 
@@ -738,7 +746,7 @@ Actions~
                 Any of the panels.
 
                                                 *diffview-available-actions*
-Available Actions~
+Available Actions ~
 
 close                                           *diffview-actions-close*
         Contexts: `view`, `panel`
@@ -978,7 +986,7 @@ view_windo({cmd}, [targets])                    *diffview-actions-view_windo*
                 |diffview-config-view.x.layout|.
 
                                                 *diffview-unused-actions*
-Unused actions~
+Unused actions ~
 
 Not all actions are mapped by default. The unused actions offer variations on
 the functionality provided by other actions, or just different functionality
@@ -1037,7 +1045,7 @@ file panel.
             • |diffview-actions|
 
                                                 *diffview-file-inference*
-File inference~
+File inference ~
 
 Actions that target a file will infer the target file according to a set of
 simple rules:
@@ -1048,7 +1056,7 @@ simple rules:
           the entry under the cursor.
 
                                                 *diffview-maps-view*
-View maps~
+View maps ~
 
 These maps are available in the diff buffers while a Diffview is the current
 tabpage.
@@ -1087,7 +1095,7 @@ gf                      Open the local version of the file in a new split in a
 y                       Copy the commit hash of the entry under the cursor.
 
                                                 *diffview-maps-file-panel*
-File panel maps~
+File panel maps ~
 
 These maps are available in the file panel buffer.
 
@@ -1134,7 +1142,7 @@ R                       Update the stats and entries in the file list.
 <leader>e               Bring focus to the file panel.
 
                                                 *diffview-maps-file-history-panel*
-File history panel maps~
+File history panel maps ~
 
 These mappings are available in the file history panel buffer (the panel
 listing the commits).
@@ -1174,7 +1182,7 @@ o                       Open the diff for the selected item.
 <leader>e               Bring focus to the file history panel.
 
                                                 *diffview-maps-file-history-option-panel*
-File history option panel maps~
+File history option panel maps ~
 
 These mappings are available from the file history option panel. The option
 panel will allow you to change the flags that will be passed to `git-log`. A

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -9,6 +9,8 @@ local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModu
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
+local api = vim.api
+
 local M = {}
 
 local fstat_cache = {}
@@ -168,8 +170,28 @@ function FileEntry:validate_stage_buffers(adapter, stat)
   if stat then
     if not cached_stat or cached_stat.mtime < stat.mtime.sec then
       for _, f in ipairs(self.layout:files()) do
-        if f.rev.type == RevType.STAGE then
-          f:dispose_buffer()
+        if f.rev.type == RevType.STAGE and f:is_valid() then
+          if f.rev.stage == 0 then
+            local is_modified = vim.bo[f.bufnr].modified
+
+            if f.blob_hash then
+              local new_hash = f.adapter:file_blob_hash(f.path)
+              if new_hash and new_hash ~= f.blob_hash and is_modified then
+                utils.warn((
+                  "A file was changed in the index since you started editing it!"
+                  .. " Be careful not to lose any staged changes when writing to this buffer: %s"
+                ):format(api.nvim_buf_get_name(f.bufnr)))
+              end
+            elseif not is_modified then
+              -- Should be very rare that we don't have an index-buffer's blob
+              -- hash. But in that case, we can't warn the user when a file
+              -- changes in the index while they're editing its index buffer.
+              f:dispose_buffer()
+            end
+
+          else
+            f:dispose_buffer()
+          end
         end
       end
     end

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -98,6 +98,14 @@ function VCSAdapter:head_rev()
   oop.abstract_stub()
 end
 
+---Get the hash for a file's blob in a given rev.
+---@param path string
+---@param rev_arg string?
+---@return string?
+function VCSAdapter:file_blob_hash(path, rev_arg)
+  oop.abstract_stub()
+end
+
 ---@return string[] # path to binary for VCS command
 function VCSAdapter:get_command()
   oop.abstract_stub()
@@ -284,6 +292,7 @@ function VCSAdapter:file_restore(path, kind, commit)
   oop.abstract_stub()
 end
 
+---Update the index entry for a given file with the contents of an index buffer.
 ---@param file vcs.File
 ---@return boolean success
 function VCSAdapter:stage_index_file(file)

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -284,6 +284,12 @@ function VCSAdapter:file_restore(path, kind, commit)
   oop.abstract_stub()
 end
 
+---@param file vcs.File
+---@return boolean success
+function VCSAdapter:stage_index_file(file)
+  oop.abstract_stub()
+end
+
 ---@diagnostic enable: unused-local, missing-return
 
 ---@param self VCSAdapter

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -1058,6 +1058,23 @@ function GitAdapter:head_rev()
   return GitRev(RevType.COMMIT, s, true)
 end
 
+---@param path string
+---@param rev_arg string?
+---@return string?
+function GitAdapter:file_blob_hash(path, rev_arg)
+  local out, code = self:exec_sync({
+    "rev-parse",
+    "--revs-only",
+    ("%s:%s"):format(rev_arg or "", path)
+  }, self.ctx.toplevel)
+
+  if code ~= 0 then
+    return
+  end
+
+  return vim.trim(out[1])
+end
+
 ---Parse two endpoint, commit revs from a symmetric difference notated rev arg.
 ---@param rev_arg string
 ---@return Rev? left The left rev.
@@ -1316,7 +1333,6 @@ function GitAdapter:stage_index_file(file)
     })
 
     vim.cmd("silent noautocmd keepalt '[,']write " .. temp)
-    print(temp)
 
     out, code = self:exec_sync(
       { "--literal-pathspecs", "hash-object", "-w", "--", pl:convert(temp) },

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -19,6 +19,7 @@ local utils = require("diffview.utils")
 
 ---@type PathLib
 local pl = lazy.access(utils, "path")
+local api = vim.api
 
 local M = {}
 
@@ -1302,6 +1303,60 @@ function GitAdapter:file_restore(path, kind, commit)
   end
 
   return true, undo
+end
+
+---@param file vcs.File
+function GitAdapter:stage_index_file(file)
+  local out, code, err
+  local temp = vim.fn.tempname()
+
+  local ok, ret = pcall(function()
+    api.nvim_exec_autocmds("BufWritePre", {
+      pattern = api.nvim_buf_get_name(file.bufnr),
+    })
+
+    vim.cmd("silent noautocmd keepalt '[,']write " .. temp)
+    print(temp)
+
+    out, code = self:exec_sync(
+      { "--literal-pathspecs", "hash-object", "-w", "--", pl:convert(temp) },
+      self.ctx.toplevel
+    )
+
+    if code ~= 0 then
+      utils.err("Failed to write file blob into the object database. Aborting.")
+      return false
+    end
+
+    local blob_hash = out[1]
+
+    out, code = self:exec_sync({ "ls-files", "--stage", file.path }, self.ctx.toplevel)
+    local old_mode = out[1]:match("^(%d+)")
+
+    if not old_mode then
+      old_mode = vim.fn.executable(file.absolute_path) and "100755" or "100644"
+    end
+
+    out, code, err = self:exec_sync({ "update-index", "--index-info" }, {
+      cwd = self.ctx.toplevel,
+      writer = ("%s %s %d\t%s"):format(old_mode, blob_hash, file.rev.stage, file.path),
+    })
+
+    if code ~= 0 then
+      utils.err(utils.vec_join("Failed to update index!", err))
+      return false
+    end
+
+    vim.bo[file.bufnr].modified = false
+    api.nvim_exec_autocmds("BufWritePost", {
+      pattern = api.nvim_buf_get_name(file.bufnr),
+    })
+  end)
+
+  vim.fn.delete(temp)
+  if not ok then error(ret) end
+
+  return ret
 end
 
 function GitAdapter:reset_files(paths)


### PR DESCRIPTION

This finally brings over a really nice feature from Fugitive that allows you to stage individual hunks by editing any buffer that represents the index (after running `:DiffviewOpen` with no `[git-rev]` the entries under "Changes" will have the index buffer on the left side, and the entries under "Staged changes" will have it on the right side). Once you write to an index buffer, the index will be updated.

### For those unfamiliar with the feature from Fugitive:

This makes the staging workflow play really nicely with the builtin `:h copy-diffs` commands. After moving the cursor to a diff hunk in an index buffer, you can simply press `do` to obtain the hunk from the other side. When you now `:w` the index buffer you will have staged that individual hunk.

It's now equally trivial to undo individual hunks from the staged changes. All the entries in the "Staged changes" section show a diff between the HEAD on the left and the index on the right. Thus, bringing the cursor to a hunk in the index buffer, pressing `do` to obtain the content from the HEAD version, and finally `:write`-ing the index buffer will unstage that hunk.

Having editable index buffers gives you great control over exactly what gets staged, as you can now edit the index the same way you edit all text in (N)vim.

### How do I identify an index buffer?

Again, running `:DiffviewOpen` with no `[git-rev]` will have the index buffer on the left side for all the entries under the "Changes" heading, and on the right side for all entries under the "Staged changes" heading.

You can also identify an index buffer from the buffer name. All Diffview buffer names are URI's structured like this:

```
diffview://{git_dir}/{rev}/{path}
```

Where the variables represent the following:

- `git_dir`: Path to the git dir (typicaly the `.git` dir. But not necessarily)
- `rev`: The abbreviated revision object name. Will either be an abbreviated commit SHA, or a stage number `:[0-3]:`.
- `path`: The path to the file from the top-level of the repo.

The index in git is represented by stage number 0. So an example index buffer could be named something like this:

```
diffview:///path/to/git/dir/:0:/path/to/file
```
