### PR TITLE
feat: Show context for merge conflicts in the winbar

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -3,5 +3,6 @@
     "Lua.diagnostics.disable": [
         "assign-type-mismatch",
         "cast-type-mismatch"
-    ]
+    ],
+    "workspace.checkThirdParty": false
 }

--- a/README.md
+++ b/README.md
@@ -187,15 +187,18 @@ require("diffview").setup({
     default = {
       -- Config for changed files, and staged files in diff views.
       layout = "diff2_horizontal",
+      winbar_info = false,          -- See ':h diffview-config-view.x.winbar_info'
     },
     merge_tool = {
       -- Config for conflicted files in diff views during a merge or rebase.
       layout = "diff3_horizontal",
       disable_diagnostics = true,   -- Temporarily disable diagnostics for conflict buffers while in the view.
+      winbar_info = true,           -- See ':h diffview-config-view.x.winbar_info'
     },
     file_history = {
       -- Config for changed files in file history views.
       layout = "diff2_horizontal",
+      winbar_info = false,          -- See ':h diffview-config-view.x.winbar_info'
     },
   },
   file_panel = {

--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -406,6 +406,12 @@ view.x.layout                                   *diffview-config-view.x.layout*
                 │              │
                 └──────────────┘
 
+view.x.winbar_info                              *diffview-config-view.x.winbar_info*
+        Type: `boolean`, Default: (see example config above)
+
+        Use the 'winbar' to show contextual info about the different versions
+        of a file in a diff.
+
                                                 *diffview-config-view.merge_tool.disable_diagnostics*
 view.merge_tool.disable_diagnostics
         Type: `boolean`, Default: `true`

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -35,15 +35,18 @@ require("diffview").setup({
     default = {
       -- Config for changed files, and staged files in diff views.
       layout = "diff2_horizontal",
+      winbar_info = false,          -- See |diffview-config-view.x.winbar_info|
     },
     merge_tool = {
       -- Config for conflicted files in diff views during a merge or rebase.
       layout = "diff3_horizontal",
       disable_diagnostics = true,   -- Temporarily disable diagnostics for conflict buffers while in the view.
+      winbar_info = true,           -- See |diffview-config-view.x.winbar_info|
     },
     file_history = {
       -- Config for changed files in file history views.
       layout = "diff2_horizontal",
+      winbar_info = false,          -- See |diffview-config-view.x.winbar_info|
     },
   },
   file_panel = {

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -53,13 +53,16 @@ M.defaults = {
   view = {
     default = {
       layout = "diff2_horizontal",
+      winbar_info = false,
     },
     merge_tool = {
       layout = "diff3_horizontal",
       disable_diagnostics = true,
+      winbar_info = true,
     },
     file_history = {
       layout = "diff2_horizontal",
+      winbar_info = false,
     },
   },
   file_panel = {

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -36,6 +36,7 @@ local fstat_cache = {}
 ---@field stats GitStats
 ---@field kind vcs.FileKind
 ---@field commit Commit|nil
+---@field merge_ctx vcs.MergeContext?
 ---@field active boolean
 local FileEntry = oop.create_class("FileEntry")
 
@@ -49,6 +50,7 @@ local FileEntry = oop.create_class("FileEntry")
 ---@field stats GitStats
 ---@field kind vcs.FileKind
 ---@field commit? Commit
+---@field merge_ctx? vcs.MergeContext
 
 ---FileEntry constructor
 ---@param opt FileEntry.init.Opt
@@ -66,6 +68,7 @@ function FileEntry:init(opt)
   self.stats = opt.stats
   self.kind = opt.kind
   self.commit = opt.commit
+  self.merge_ctx = opt.merge_ctx
   self.active = false
 end
 
@@ -125,6 +128,7 @@ function FileEntry:convert_layout(target_layout)
     c = utils.tbl_access(self.layout, "c.file") or create_file(self.revs.c, "c"),
     d = utils.tbl_access(self.layout, "d.file") or create_file(self.revs.d, "d"),
   })
+  self:update_merge_context()
 end
 
 ---@param stat? table
@@ -163,6 +167,37 @@ function FileEntry:validate_stage_buffers(stat)
         end
       end
     end
+  end
+end
+
+---Update winbar info
+---@param ctx? vcs.MergeContext
+function FileEntry:update_merge_context(ctx)
+  ctx = ctx or self.merge_ctx
+  if ctx then self.merge_ctx = ctx else return end
+
+  local layout = self.layout --[[@as Diff4 ]]
+
+  if layout.a then
+    layout.a.file.winbar = (" OURS (Current branch) %s"):format(
+      (ctx.ours.hash):sub(1, 10)
+    )
+  end
+
+  if layout.b then
+    layout.b.file.winbar = " LOCAL (Working tree)"
+  end
+
+  if layout.c then
+    layout.c.file.winbar = (" THEIRS (Incoming branch) %s"):format(
+      (ctx.theirs.hash):sub(1, 10)
+    )
+  end
+
+  if layout.d then
+    layout.d.file.winbar = (" BASE (Common ancestor) %s"):format(
+      (ctx.base.hash):sub(1, 10)
+    )
   end
 end
 

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -179,8 +179,9 @@ function FileEntry:update_merge_context(ctx)
   local layout = self.layout --[[@as Diff4 ]]
 
   if layout.a then
-    layout.a.file.winbar = (" OURS (Current branch) %s"):format(
-      (ctx.ours.hash):sub(1, 10)
+    layout.a.file.winbar = (" OURS (Current changes) %s %s"):format(
+      (ctx.ours.hash):sub(1, 10),
+      ctx.ours.ref_names and ("(" .. ctx.ours.ref_names .. ")") or ""
     )
   end
 
@@ -189,14 +190,16 @@ function FileEntry:update_merge_context(ctx)
   end
 
   if layout.c then
-    layout.c.file.winbar = (" THEIRS (Incoming branch) %s"):format(
-      (ctx.theirs.hash):sub(1, 10)
+    layout.c.file.winbar = (" THEIRS (Incoming changes) %s %s"):format(
+      (ctx.theirs.hash):sub(1, 10),
+      ctx.theirs.ref_names and ("(" .. ctx.theirs.ref_names .. ")") or ""
     )
   end
 
   if layout.d then
-    layout.d.file.winbar = (" BASE (Common ancestor) %s"):format(
-      (ctx.base.hash):sub(1, 10)
+    layout.d.file.winbar = (" BASE (Common ancestor) %s %s"):format(
+      (ctx.base.hash):sub(1, 10),
+      ctx.base.ref_names and ("(" .. ctx.base.ref_names .. ")") or ""
     )
   end
 end

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -186,6 +186,11 @@ function StandardView:use_entry(entry)
       layout.c.file.winopts,
       self.winopts.diff4.c or {}
     )
+    layout.d.file.winopts = vim.tbl_extend(
+      "force",
+      layout.d.file.winopts,
+      self.winopts.diff4.d or {}
+    )
   end
 
   local old_layout = self.cur_layout

--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -94,6 +94,10 @@ function Window:open_file(callback)
             and config.get_config().view.merge_tool.disable_diagnostics,
       })
 
+      if self.file.winbar then
+        vim.wo[self.id].winbar = self.file.winbar
+      end
+
       api.nvim_win_call(self.id, function()
         DiffviewGlobal.emitter:emit("diff_buf_win_enter", self.file.bufnr, self.id)
       end)
@@ -103,6 +107,8 @@ function Window:open_file(callback)
         callback(self.file)
       end
     end
+
+    vim.wo[self.id].winbar = nil
 
     if self.file:is_valid() then
       on_load()
@@ -114,6 +120,7 @@ end
 
 function Window:open_null()
   if self:is_valid() then
+    vim.wo[self.id].winbar = nil
     File.load_null_buffer(self.id)
   end
 end

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -131,8 +131,8 @@ end
 ---@return string[] stdout
 ---@return integer code
 ---@return string[] stderr
----@overload fun(args: string[], cwd: string?)
----@overload fun(args: string[], opt: utils.system_list.Opt?)
+---@overload fun(self: VCSAdapter, args: string[], cwd: string?)
+---@overload fun(self: VCSAdapter, args: string[], opt: utils.system_list.Opt?)
 function VCSAdapter:exec_sync(args, cwd_or_opt)
   if not self.bootstrap.done then
     self:run_bootstrap()
@@ -176,6 +176,16 @@ end
 ---@param args string[]
 ---@return string[] args to show commit log message
 function VCSAdapter:get_log_args(args)
+  oop.abstract_stub()
+end
+
+---@class vcs.MergeContext
+---@field ours { hash: string, ref_names: string? }
+---@field theirs { hash: string, ref_names: string? }
+---@field base { hash: string, ref_names: string? }
+
+---@return vcs.MergeContext
+function VCSAdapter:get_merge_context()
   oop.abstract_stub()
 end
 

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -285,7 +285,7 @@ function GitAdapter:get_merge_context()
 
   ret.base = {
     hash = out[1],
-    ref_names = self:exec_sync({ "show", "-s", "--pretty=format:%D" }, self.ctx.toplevel)[1],
+    ref_names = self:exec_sync({ "show", "-s", "--pretty=format:%D", out[1] }, self.ctx.toplevel)[1],
   }
 
   return ret

--- a/lua/diffview/vcs/adapters/git/rev.lua
+++ b/lua/diffview/vcs/adapters/git/rev.lua
@@ -128,12 +128,20 @@ function GitRev:is_head(adapter)
   return self.commit == vim.trim(out[1]):gsub("^%^", "")
 end
 
-function GitRev:object_name()
+---@param abbrev_len? integer
+---@return string
+function GitRev:object_name(abbrev_len)
   if self.type == RevType.COMMIT then
+    if abbrev_len then
+      return self.commit:sub(1, abbrev_len)
+    end
+
     return self.commit
   elseif self.type == RevType.STAGE then
     return ":" ..  self.stage
   end
+
+  return "UNKNOWN"
 end
 
 M.GitRev = GitRev

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -80,6 +80,26 @@ function File:init(opt)
     foldlevel = 0,
     foldenable = true,
   }
+
+  -- Set winbar info
+  if self.rev then
+    local winbar
+
+    if self.rev.type == RevType.LOCAL then
+      winbar = " WORKING TREE - ${path}"
+    elseif self.rev.type == RevType.COMMIT then
+      winbar = " ${object_path}"
+    elseif self.rev.type == RevType.STAGE then
+      winbar = " INDEX - ${object_path}"
+    end
+
+    if winbar then
+      self.winbar = utils.str_template(winbar, {
+        path = self.path,
+        object_path = self.rev:object_name(10) .. ":" .. self.path,
+      })
+    end
+  end
 end
 
 ---@param force? boolean Also delete buffers for LOCAL files.

--- a/lua/diffview/vcs/rev.lua
+++ b/lua/diffview/vcs/rev.lua
@@ -101,11 +101,13 @@ function Rev:is_head(adapter)
   oop.abstract_stub()
 end
 
----@diagnostic enable: unused-local, missing-return
-
-function Rev:object_name()
+---@param abbrev_len? integer
+---@return string
+function Rev:object_name(abbrev_len)
   oop.abstract_stub()
 end
+
+---@diagnostic enable: unused-local, missing-return
 
 ---Get an abbreviated commit SHA. Returns `nil` if this Rev is not a commit.
 ---@param length integer|nil


### PR DESCRIPTION
Resolves #282 

```vimhelp
view.x.winbar_info                              *diffview-config-view.x.winbar_info*
        Type: `boolean`, Default: (see example config above)

        Use the 'winbar' to show contextual info about the different versions
        of a file in a diff.
```