### PR TITLE
conflicts: handle FETCH_HEAD conflicts

### DIFF
--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -257,7 +257,7 @@ end
 function GitAdapter:get_merge_context()
   local their_head
 
-  for _, name in ipairs({ "MERGE_HEAD", "REBASE_HEAD", "REVERT_HEAD" }) do
+  for _, name in ipairs({ "MERGE_HEAD", "REBASE_HEAD", "REVERT_HEAD", "FETCH_HEAD" }) do
     if pl:readable(pl:join(self.ctx.dir, name)) then
       their_head = name
       break


### PR DESCRIPTION
needed this to have diffview correctly appear after I got a merge conflict. `their_head` was nil, as it turns out, because diffview didn't expect that exact scenario.

i'm otherwise not exactly sure what I did in this case that was so special.