### PR TITLE
feat: rocks.nvim/luarocks support

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,34 @@
+---
+name: "luarocks upload"
+on:
+  push:
+    tags:
+      - '*'
+  release: 
+    types:
+      - created # Triggered by release-please
+  pull_request: # Tests a local luarocks install without publishing on PRs
+  workflow_dispatch: # Allow manual trigger
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        # Tags created by GitHub releases don't trigger push: tags workflows
+        # So we have to determine the tag manually.
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          detailed_description: |
+            Vim's diff mode is pretty good, but there is no convenient way to quickly bring up all modified files in a diffsplit.
+            This plugin aims to provide a simple, unified, single tabpage interface that lets you easily review all changed files for any git rev.
+          license: "GPL-3.0"
+          dependencies: |
+            nvim-web-devicons

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+---
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        with:
+          release-type: simple
+          package-name: diffview.nvim

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ for any git rev.
 
 ## Installation
 
+[![LuaRocks](https://img.shields.io/luarocks/v/sindrets/diffview.nvim?logo=lua&color=purple)](https://luarocks.org/modules/sindrets/diffview.nvim)
+
 Install the plugin with your package manager of choice.
 
 ```vim

--- a/diffview.nvim-scm-1.rockspec
+++ b/diffview.nvim-scm-1.rockspec
@@ -1,0 +1,32 @@
+local _MODREV, _SPECREV = 'scm', '-1'
+rockspec_format = "3.0"
+package = 'diffview.nvim'
+version = _MODREV .. _SPECREV
+
+description = {
+   summary = 'Single tabpage interface for easily cycling through diffs for all modified files for any git rev.',
+   labels = { 'neovim', 'neovim-plugin', 'git', 'diff', 'neovim-lua', 'neovim-lua-plugin', },
+   detailed = [[
+     Vim's diff mode is pretty good, but there is no convenient way to quickly bring up all modified files in a diffsplit.
+     This plugin aims to provide a simple, unified, single tabpage interface that lets you easily review all changed files for any git rev.
+   ]],
+   homepage = 'https://github.com/sindrets/diffview.nvim',
+   license = 'GPL-3.0',
+}
+
+dependencies = {
+   'lua >= 5.1, < 5.4',
+   'nvim-web-devicons',
+}
+
+source = {
+   url = 'git://github.com/sindrets/diffview.nvim',
+}
+
+build = {
+   type = 'builtin',
+   copy_directories = {
+     'doc',
+     'plugin',
+   },
+}


### PR DESCRIPTION
### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.
* See also: [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.

### Things done:

* Add a release-please workflow that creates release PRs with SemVer versioning based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
* Add a workflow that publishes tags to LuaRocks when a tag or release is pushed.

The workflows are based on [this guide](https://github.com/vhyrro/sample-luarocks-plugin) by @vhyrro.

### Notes:

> [!IMPORTANT]
> 
> - **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.

* On each merge to `main`, the `release-please` workflow creates (or updates an existing) release PR.
* You decide when to merge release PRs.
  Doing so will result in a SemVer tag, and a GitHub release, which will trigger the `luarocks` workflow.
* Tagged releases are installed locally and then published to luarocks.org.
  On PRs, a test release is installed, but not published.
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.

__Adding the API key (screen shot)__
![github-add-luarocks-api-key](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)