### PR TITLE
feat(file-history): Hide unrelated changes when tracing line evolution

### DIFF
--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -29,6 +29,8 @@ local M = setmetatable({}, {
   end
 })
 
+M.compat = {}
+
 ---@return FileEntry?
 ---@return integer[]? cursor
 local function prepare_goto_file()
@@ -273,7 +275,7 @@ function M.scroll_view(distance)
     scroll_cmd = ([[exe "norm! %d%s"]]):format(distance, scroll_opr)
   else
     scroll_cmd = ([[exe "norm! " . float2nr(winheight(0) * %f) . "%s"]])
-        :format(distance, scroll_opr)
+        :format(math.abs(distance), scroll_opr)
   end
 
   return function()
@@ -285,9 +287,9 @@ function M.scroll_view(distance)
       local target
 
       for _, win in ipairs(view.cur_layout.windows) do
-        local c = api.nvim_buf_line_count(api.nvim_win_get_buf(win.id))
-        if c > max then
-          max = c
+        local height = utils.win_content_height(win.id)
+        if height > max then
+          max = height
           target = win.id
         end
       end
@@ -489,6 +491,53 @@ function M.help(keymap_groups)
       local help_panel = HelpPanel(view, keymap_groups) --[[@as HelpPanel ]]
       help_panel:focus()
     end
+  end
+end
+
+do
+  M.compat.fold_cmds = {}
+
+  -- For file entries that use custom folds with `foldmethod=manual` we need to
+  -- replicate fold commands in all diff windows, as folds are only
+  -- synchronized between diff windows when `foldmethod=diff`.
+  local function compat_fold(fold_cmd)
+    return function()
+      if vim.wo.foldmethod ~= "manual" then
+        local ok, msg = pcall(vim.cmd, "norm! " .. fold_cmd)
+        if not ok and msg then
+          api.nvim_err_writeln(msg)
+        end
+        return
+      end
+
+      local view = lib.get_current_view()
+
+      if view and view:instanceof(StandardView.__get()) then
+        ---@cast view StandardView
+        local err
+
+        for _, win in ipairs(view.cur_layout.windows) do
+          api.nvim_win_call(win.id, function()
+            local ok, msg = pcall(vim.cmd, "norm! " .. fold_cmd)
+            if not ok then err = msg end
+          end)
+        end
+
+        if err then api.nvim_err_writeln(err) end
+      end
+    end
+  end
+
+  for _, fold_cmd in ipairs({
+    "za", "zA", "ze", "zE", "zo", "zc", "zO", "zC", "zr", "zm", "zR", "zM",
+    "zv", "zx", "zX", "zn", "zN", "zi",
+  }) do
+    table.insert(M.compat.fold_cmds, {
+      "n",
+      fold_cmd,
+      compat_fold(fold_cmd),
+      { desc = "diffview_ignore" },
+    })
   end
 end
 

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -132,6 +132,7 @@ M.defaults = {
       { "n", "<leader>cb", actions.conflict_choose("base"),    { desc = "Choose the BASE version of a conflict" } },
       { "n", "<leader>ca", actions.conflict_choose("all"),     { desc = "Choose all the versions of a conflict" } },
       { "n", "dx",         actions.conflict_choose("none"),    { desc = "Delete the conflict region" } },
+      unpack(actions.compat.fold_cmds),
     },
     diff1 = {
       -- Mappings in single window diff layouts

--- a/lua/diffview/scanner.lua
+++ b/lua/diffview/scanner.lua
@@ -1,0 +1,46 @@
+local oop = require("diffview.oop")
+
+---@class Scanner : diffview.Object
+---@operator call : Scanner
+---@field lines string[]
+---@field line_idx integer
+local Scanner = oop.create_class("Scanner")
+
+---@param source string|string[]
+function Scanner:init(source)
+  if type(source) == "table" then
+    self.lines = source
+  else
+    self.lines = vim.split(source, "\n")
+  end
+
+  self.line_idx = 0
+end
+
+---Peek the nth line after the current line.
+---@param n? integer # (default: 1)
+---@return string?
+function Scanner:peek_line(n)
+  return self.lines[self.line_idx + math.max(1, n or 1)]
+end
+
+function Scanner:cur_line()
+  return self.lines[self.line_idx]
+end
+
+---Advance the scanner to the next line.
+---@return string?
+function Scanner:next_line()
+  self.line_idx = self.line_idx + 1
+  return self.lines[self.line_idx]
+end
+
+---Advance the scanner by n lines.
+---@param n? integer # (default: 1)
+---@return string?
+function Scanner:skip_line(n)
+  self.line_idx = self.line_idx + math.max(1, n or 1)
+  return self.lines[self.line_idx]
+end
+
+return Scanner

--- a/lua/diffview/scanner.lua
+++ b/lua/diffview/scanner.lua
@@ -28,6 +28,10 @@ function Scanner:cur_line()
   return self.lines[self.line_idx]
 end
 
+function Scanner:cur_line_idx()
+  return self.line_idx
+end
+
 ---Advance the scanner to the next line.
 ---@return string?
 function Scanner:next_line()

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -1,6 +1,7 @@
 local lazy = require("diffview.lazy")
 local oop = require("diffview.oop")
 
+local Diff2 = lazy.access("diffview.scene.layouts.diff_2", "Diff2") ---@type Diff2|LazyModule
 local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
@@ -38,6 +39,7 @@ local fstat_cache = {}
 ---@field commit Commit|nil
 ---@field merge_ctx vcs.MergeContext?
 ---@field active boolean
+---@field opened boolean
 local FileEntry = oop.create_class("FileEntry")
 
 ---@class FileEntry.init.Opt
@@ -70,6 +72,7 @@ function FileEntry:init(opt)
   self.commit = opt.commit
   self.merge_ctx = opt.merge_ctx
   self.active = false
+  self.opened = false
 end
 
 function FileEntry:destroy()
@@ -201,6 +204,50 @@ function FileEntry:update_merge_context(ctx)
       (ctx.base.hash):sub(1, 10),
       ctx.base.ref_names and ("(" .. ctx.base.ref_names .. ")") or ""
     )
+  end
+end
+
+---@param diff diff.FileEntry
+function FileEntry:update_patch_folds(diff)
+  if not self.layout:instanceof(Diff2.__get()) then return end
+
+  local layout = self.layout --[[@as Diff2 ]]
+  local folds = {
+    a = utils.tbl_set(layout.a.file, { "custom_folds" }, {}),
+    b = utils.tbl_set(layout.b.file, { "custom_folds" }, {}),
+  }
+
+  local lcount_a = api.nvim_buf_line_count(layout.a.file.bufnr)
+  local lcount_b = api.nvim_buf_line_count(layout.b.file.bufnr)
+
+  local prev_last_old, prev_last_new = 0, 0
+
+  for i = 1, #diff.hunks + 1 do
+    local hunk = diff.hunks[i]
+    local first_old, last_old, first_new, last_new
+
+    if hunk then
+      first_old = hunk.old_row - 1
+      last_old = first_old + hunk.old_size - 1
+      first_new = hunk.new_row - 1
+      last_new = first_new + hunk.new_size - 1
+    else
+      first_old = lcount_a
+      first_new = lcount_b
+    end
+
+    if first_old - prev_last_old > 1 then
+      table.insert(folds.a, { prev_last_old, first_old })
+      -- print("old:", folds.a[#folds.a][1], folds.a[#folds.a][2])
+    end
+
+    if first_new - prev_last_new > 1 then
+      table.insert(folds.b, { prev_last_new, first_new })
+      -- print("new:", folds.b[#folds.b][1], folds.b[#folds.b][2])
+    end
+
+    prev_last_old = last_old
+    prev_last_new = last_new
   end
 end
 

--- a/lua/diffview/scene/file_entry.lua
+++ b/lua/diffview/scene/file_entry.lua
@@ -214,8 +214,8 @@ function FileEntry:update_patch_folds(diff)
 
   local layout = self.layout --[[@as Diff2 ]]
   local folds = {
-    a = utils.tbl_set(layout.a.file, { "custom_folds" }, {}),
-    b = utils.tbl_set(layout.b.file, { "custom_folds" }, {}),
+    a = utils.tbl_set(layout.a.file, { "custom_folds" }, { type = "diff_patch" }),
+    b = utils.tbl_set(layout.b.file, { "custom_folds" }, { type = "diff_patch" }),
   }
 
   local lcount_a = api.nvim_buf_line_count(layout.a.file.bufnr)
@@ -264,6 +264,18 @@ function FileEntry:update_patch_folds(diff)
     prev_last_old = last_old
     prev_last_new = last_new
   end
+end
+
+---Check if the entry has custom diff patch folds.
+---@return boolean
+function FileEntry:has_patch_folds()
+  for _, file in ipairs(self.layout:files()) do
+    if not file.custom_folds or file.custom_folds.type ~= "diff_patch" then
+      return false
+    end
+  end
+
+  return true
 end
 
 ---@static

--- a/lua/diffview/scene/layout.lua
+++ b/lua/diffview/scene/layout.lua
@@ -307,12 +307,15 @@ function Layout:sync_scroll()
     if lcount > max then target, max = win, lcount end
   end
 
+  local main_win = self:get_main_win()
+  local cursor = api.nvim_win_get_cursor(main_win.id)
+
   for _, win in ipairs(self.windows) do
     api.nvim_win_call(win.id, function()
       if win == target then
         -- Scroll to trigger the scrollbind and sync the windows. This works more
         -- consistently than calling `:syncbind`.
-        vim.cmd([[exe "norm! \<c-e>\<c-y>"]])
+        vim.cmd("norm! " .. api.nvim_replace_termcodes("<c-e><c-y>", true, true, true))
       end
 
       if win.id ~= curwin then
@@ -320,6 +323,9 @@ function Layout:sync_scroll()
       end
     end)
   end
+
+  -- Cursor will sometimes move +- the value of 'scrolloff'
+  api.nvim_win_set_cursor(target.id, cursor)
 end
 
 M.Layout = Layout

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -184,6 +184,11 @@ function DiffView:_set_file(file)
 
   file.layout.emitter:once("files_opened", function()
     self.emitter:emit("file_open_post", file, cur_entry)
+
+    if not self.cur_entry.opened then
+      self.cur_entry.opened = true
+      DiffviewGlobal.emitter:emit("file_open_new", file)
+    end
   end)
 
   self:use_entry(file)

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -41,15 +41,17 @@ return function(view)
         end
       end
     end,
-    diff_buf_read = function(_)
-      utils.set_cursor(0, 1, 0)
+    file_open_new = function(_, entry)
+      api.nvim_win_call(view.cur_layout:get_main_win().id, function()
+        utils.set_cursor(0, 1, 0)
 
-      if view.cur_layout:get_main_win().id == api.nvim_get_current_win() then
         if view.cur_entry and view.cur_entry.kind == "conflicting" then
           actions.next_conflict()
           vim.cmd("norm! zz")
         end
-      end
+      end)
+
+      view.cur_layout:sync_scroll()
     end,
     ---@diagnostic disable-next-line: unused-local
     files_updated = function(_, files)

--- a/lua/diffview/scene/views/file_history/file_history_view.lua
+++ b/lua/diffview/scene/views/file_history/file_history_view.lua
@@ -95,7 +95,10 @@ function FileHistoryView:_set_file(file)
   file.layout.emitter:once("files_opened", function()
     local log_options = self.panel:get_log_options()
 
-    if log_options.L and next(log_options.L) then
+    -- For line tracing diffs: create custom folds derived from the diff patch
+    -- hunks. Should not be used with custom `++base` as then we won't know
+    -- where to create the custom folds in the base file.
+    if log_options.L and next(log_options.L) and not log_options.base then
       local log_entry = self.panel.cur_item[1]
       local diff = log_entry:get_diff(file.path)
 

--- a/lua/diffview/scene/views/file_history/file_history_view.lua
+++ b/lua/diffview/scene/views/file_history/file_history_view.lua
@@ -102,7 +102,7 @@ function FileHistoryView:_set_file(file)
       local log_entry = self.panel.cur_item[1]
       local diff = log_entry:get_diff(file.path)
 
-      if diff then
+      if diff and not file:has_patch_folds() then
         file:update_patch_folds(diff)
 
         for _, win in ipairs(self.cur_layout.windows) do

--- a/lua/diffview/scene/views/file_history/file_history_view.lua
+++ b/lua/diffview/scene/views/file_history/file_history_view.lua
@@ -93,7 +93,28 @@ function FileHistoryView:_set_file(file)
   self.nulled = false
 
   file.layout.emitter:once("files_opened", function()
+    local log_options = self.panel:get_log_options()
+
+    if log_options.L and next(log_options.L) then
+      local log_entry = self.panel.cur_item[1]
+      local diff = log_entry:get_diff(file.path)
+
+      if diff then
+        file:update_patch_folds(diff)
+
+        for _, win in ipairs(self.cur_layout.windows) do
+          win:use_winopts({ foldmethod = "manual" })
+          win:apply_custom_folds()
+        end
+      end
+    end
+
     self.emitter:emit("file_open_post", file, cur_entry)
+
+    if not self.cur_entry.opened then
+      self.cur_entry.opened = true
+      DiffviewGlobal.emitter:emit("file_open_new", file)
+    end
   end)
 
   self:use_entry(file)

--- a/lua/diffview/scene/views/file_history/listeners.lua
+++ b/lua/diffview/scene/views/file_history/listeners.lua
@@ -27,33 +27,9 @@ return function(view)
         end
       end
     end,
-    diff_buf_read = function(_, bufnr)
-      -- Set the cursor at the beginning of the -L range if possible.
-
-      local log_options = view.panel:get_log_options()
-      local cur = view.panel:cur_file()
-
-      if log_options.L and log_options.L[1] and bufnr == cur.layout:get_main_win().file.bufnr then
-        for _, value in ipairs(log_options.L) do
-          local l1, lpath = value:match("^(%d+),.*:(.*)")
-
-          if l1 then
-            l1 = tonumber(l1)
-            lpath = utils.path:chain(lpath)
-                :normalize({ cwd = view.adapter.ctx.toplevel, absolute = true })
-                :relative(view.adapter.ctx.toplevel)
-                :get()
-
-            if lpath == cur.path then
-              utils.set_cursor(0, l1, 0)
-              vim.cmd("norm! zt")
-              break
-            end
-          end
-        end
-      else
-        utils.set_cursor(0, 1, 0)
-      end
+    file_open_new = function(_, entry)
+      utils.set_cursor(view.cur_layout:get_main_win().id, 1, 0)
+      view.cur_layout:sync_scroll()
     end,
     open_in_diffview = function()
       local file = view:infer_cur_file()

--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -1,6 +1,7 @@
 local lazy = require("diffview.lazy")
 local oop = require("diffview.oop")
 
+local EventEmitter = lazy.access("diffview.events", "EventEmitter") ---@type EventEmitter|LazyModule
 local File = lazy.access("diffview.vcs.file", "File") ---@type vcs.File|LazyModule
 local FileHistoryView = lazy.access("diffview.scene.views.file_history.file_history_view", "FileHistoryView") ---@type FileHistoryView|LazyModule
 local RevType = lazy.access("diffview.vcs.rev", "RevType") ---@type RevType|LazyModule
@@ -9,6 +10,8 @@ local lib = lazy.require("diffview.lib") ---@module "diffview.lib"
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
 local api = vim.api
+local fmt = string.format
+
 local M = {}
 
 local HAS_NVIM_0_8 = vim.fn.has("nvim-0.8") == 1
@@ -17,6 +20,7 @@ local HAS_NVIM_0_8 = vim.fn.has("nvim-0.8") == 1
 ---@field id integer
 ---@field file vcs.File
 ---@field parent Layout
+---@field emitter EventEmitter
 local Window = oop.create_class("Window")
 
 Window.winopt_store = {}
@@ -31,6 +35,9 @@ function Window:init(opt)
   self.id = opt.id
   self.file = opt.file
   self.parent = opt.parent
+  self.emitter = EventEmitter()
+
+  self.emitter:on("post_open", utils.bind(self.post_open, self))
 end
 
 function Window:destroy()
@@ -45,6 +52,14 @@ end
 ---@return boolean
 function Window:is_valid()
   return self.id and api.nvim_win_is_valid(self.id)
+end
+
+---@return boolean
+function Window:is_file_open()
+  return self:is_valid()
+    and self.file
+    and self.file:is_valid()
+    and api.nvim_win_get_buf(self.id) == self.file.bufnr
 end
 
 ---@param force? boolean
@@ -65,7 +80,9 @@ function Window:is_focused()
   return self:is_valid() and api.nvim_get_current_win() == self.id
 end
 
-function Window:pre_open() end
+function Window:post_open()
+  self:apply_custom_folds()
+end
 
 ---@param callback fun(file: vcs.File)
 function Window:load_file(callback)
@@ -93,7 +110,12 @@ function Window:open_file(callback)
         self:_save_winopts()
       end
 
-      self:apply_file_winopts()
+      if self:is_nulled() then
+        self:apply_null_winopts()
+      else
+        self:apply_file_winopts()
+      end
+
       self.file:attach_buffer(false, {
         keymaps = config.get_layout_keymaps(self.parent),
         disable_diagnostics = self.file.kind == "conflicting"
@@ -103,6 +125,8 @@ function Window:open_file(callback)
       if self:show_winbar_info() then
         vim.wo[self.id].winbar = self.file.winbar
       end
+
+      self.emitter:emit("post_open")
 
       api.nvim_win_call(self.id, function()
         DiffviewGlobal.emitter:emit("diff_buf_win_enter", self.file.bufnr, self.id, {
@@ -117,7 +141,7 @@ function Window:open_file(callback)
       end
     end
 
-    self:pre_open()
+    self.emitter:emit("pre_open")
 
     if self.file:is_valid() then
       on_load()
@@ -147,9 +171,13 @@ function Window:show_winbar_info()
   return false
 end
 
+function Window:is_nulled()
+  return self:is_valid() and api.nvim_win_get_buf(self.id) == File.NULL_FILE.bufnr
+end
+
 function Window:open_null()
   if self:is_valid() then
-    self:pre_open()
+    self.emitter:emit("pre_open")
     File.load_null_buffer(self.id)
   end
 end
@@ -214,6 +242,45 @@ end
 function Window:apply_null_winopts()
   if File.NULL_FILE.winopts then
     utils.set_local(self.id, File.NULL_FILE.winopts)
+  end
+end
+
+---Use the given map of local options. These options are saved and restored
+---when the file gets unloaded.
+---@param opts WindowOptions
+function Window:use_winopts(opts)
+  if not self:is_file_open() then
+    self.emitter:once("post_open", utils.bind(self.use_winopts, self, opts))
+    return
+  end
+
+  local opt_store = utils.tbl_ensure(Window.winopt_store, { self.file.bufnr })
+
+  api.nvim_win_call(self.id, function()
+    for option, v in pairs(opts) do
+      if opt_store[option] == nil then
+        opt_store[option] = vim.o[option]
+      end
+
+      self.file.winopts[option] = v
+      utils.set_local(self.id, { [option] = v })
+    end
+  end)
+end
+
+function Window:apply_custom_folds()
+  if self.file.custom_folds and next(self.file.custom_folds)
+    and not self:is_nulled()
+    and vim.wo[self.id].foldmethod == "manual"
+  then
+    api.nvim_win_call(self.id, function()
+      pcall(vim.cmd, "norm! zE") -- Delete all folds in the window
+
+      for _, fold in ipairs(self.file.custom_folds) do
+        vim.cmd(fmt("%d,%dfold", fold[1], fold[2]))
+        -- print(fmt("%d,%dfold", fold[1], fold[2]))
+      end
+    end)
   end
 end
 

--- a/lua/diffview/scene/window.lua
+++ b/lua/diffview/scene/window.lua
@@ -269,7 +269,7 @@ function Window:use_winopts(opts)
 end
 
 function Window:apply_custom_folds()
-  if self.file.custom_folds and next(self.file.custom_folds)
+  if self.file.custom_folds
     and not self:is_nulled()
     and vim.wo[self.id].foldmethod == "manual"
   then

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -1182,6 +1182,36 @@ function M.win_find_buf(bufid, tabpage)
   return result
 end
 
+---Get the height of the content currently in a window's view, diregarding
+---virtual / filler lines.
+---@param winid integer
+---@return integer
+function M.win_content_height(winid)
+  if winid == 0 then winid = api.nvim_get_current_win() end
+  ---@diagnostic disable-next-line: redundant-parameter
+  local topline = vim.fn.line("w0", winid)
+  ---@diagnostic disable-next-line: redundant-parameter
+  local botline = vim.fn.line("w$", winid)
+  local cur = topline
+  local ret = 0
+
+  api.nvim_win_call(winid, function()
+    while cur <= botline do
+      local fold_end = vim.fn.foldclosedend(cur)
+
+      if fold_end > -1 then
+        cur = fold_end + 1
+      else
+        cur = cur + 1
+      end
+
+      ret = ret + 1
+    end
+  end)
+
+  return ret
+end
+
 ---Set the (1,0)-indexed cursor position without having to worry about
 ---out-of-bounds coordinates. The line number is clamped to the number of lines
 ---in the target buffer.

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -386,11 +386,11 @@ function GitAdapter:prepare_fh_options(log_options, single_file)
   }
 end
 
-local function structure_fh_data(namestat_data, numstat_data)
+local function structure_fh_data(namestat_data, numstat_data, keep_diff)
   local right_hash, left_hash, merge_hash = unpack(utils.str_split(namestat_data[1]))
   local time, time_offset = unpack(utils.str_split(namestat_data[3]))
 
-  return {
+  local ret = {
     left_hash = left_hash ~= "" and left_hash or nil,
     right_hash = right_hash,
     merge_hash = merge_hash,
@@ -403,6 +403,12 @@ local function structure_fh_data(namestat_data, numstat_data)
     namestat = utils.vec_slice(namestat_data, 7),
     numstat = numstat_data,
   }
+
+  if keep_diff then
+    ret.diff = vcs_utils.parse_diff(namestat_data)
+  end
+
+  return ret
 end
 
 ---@param self GitAdapter
@@ -554,7 +560,7 @@ GitAdapter.incremental_line_trace_data = async.void(function(self, state, callba
         if not shutdown then
           shutdown = callback(
             JobStatus.PROGRESS,
-            structure_fh_data(raw[trace_state.idx])
+            structure_fh_data(raw[trace_state.idx], nil, true)
           )
 
           if shutdown then
@@ -1070,6 +1076,7 @@ function GitAdapter:file_history_worker(thread, log_opt, opt, co_state, callback
       rel_date = state.cur.rel_date,
       ref_names = state.cur.ref_names,
       subject = state.cur.subject,
+      diff = state.cur.diff,
     })
 
     local ok, status

--- a/lua/diffview/vcs/commit.lua
+++ b/lua/diffview/vcs/commit.lua
@@ -17,6 +17,7 @@ local M = {}
 ---@field ref_names string
 ---@field subject string
 ---@field body string
+---@field diff? diff.FileEntry[]
 local Commit = oop.create_class("Commit")
 
 function Commit:init(opt)
@@ -27,6 +28,7 @@ function Commit:init(opt)
   self.ref_names = opt.ref_names ~= "" and opt.ref_names or nil
   self.subject = opt.subject
   self.body = opt.body
+  self.diff = opt.diff
 end
 
 ---@diagnostic disable: unused-local, missing-return

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -15,6 +15,10 @@ local M = {}
 
 ---@alias git.FileDataProducer fun(kind: vcs.FileKind, path: string, pos: "left"|"right"): string[]
 
+---@class CustomFolds
+---@field type string
+---@field [integer] { [1]: integer, [2]: integer }
+
 ---@class vcs.File : diffview.Object
 ---@field adapter GitAdapter
 ---@field path string
@@ -35,7 +39,7 @@ local M = {}
 ---@field ready boolean
 ---@field winbar string?
 ---@field winopts WindowOptions
----@field custom_folds? { [1]: integer, [2]: integer }[]
+---@field custom_folds? CustomFolds
 local File = oop.create_class("vcs.File")
 
 ---@type table<integer, vcs.File.AttachState>

--- a/lua/diffview/vcs/file.lua
+++ b/lua/diffview/vcs/file.lua
@@ -35,6 +35,7 @@ local M = {}
 ---@field ready boolean
 ---@field winbar string?
 ---@field winopts WindowOptions
+---@field custom_folds? { [1]: integer, [2]: integer }[]
 local File = oop.create_class("vcs.File")
 
 ---@type table<integer, vcs.File.AttachState>

--- a/lua/diffview/vcs/log_entry.lua
+++ b/lua/diffview/vcs/log_entry.lua
@@ -67,5 +67,17 @@ function LogEntry:update_stats()
   end
 end
 
+---@param path string
+---@return diff.FileEntry?
+function LogEntry:get_diff(path)
+  if not self.commit.diff then return nil end
+
+  for _, diff_entry in ipairs(self.commit.diff) do
+    if diff_entry.path_new == path then
+      return diff_entry
+    end
+  end
+end
+
 M.LogEntry = LogEntry
 return M

--- a/lua/diffview/vcs/log_entry.lua
+++ b/lua/diffview/vcs/log_entry.lua
@@ -73,7 +73,7 @@ function LogEntry:get_diff(path)
   if not self.commit.diff then return nil end
 
   for _, diff_entry in ipairs(self.commit.diff) do
-    if diff_entry.path_new == path then
+    if path == (diff_entry.path_new or diff_entry.path_old) then
       return diff_entry
     end
   end

--- a/lua/diffview/vcs/utils.lua
+++ b/lua/diffview/vcs/utils.lua
@@ -1,3 +1,4 @@
+local Scanner = require("diffview.scanner")
 local CountDownLatch = require("diffview.control").CountDownLatch
 local FileDict = require("diffview.vcs.file_dict").FileDict
 local Job = require("plenary.job")
@@ -239,6 +240,234 @@ M.restore_file = async.wrap(function(adapter, path, kind, commit, callback)
 
   callback()
 end, 5)
+
+--[[
+Standard change:
+
+diff --git a/lua/diffview/health.lua b/lua/diffview/health.lua
+index c05dcda..07bdd33 100644
+--- a/lua/diffview/health.lua
++++ b/lua/diffview/health.lua
+@@ -48,7 +48,7 @@ function M.check()
+
+Rename with change:
+
+diff --git a/test/index_watcher_spec.lua b/test/gitdir_watcher_spec.lua
+similarity index 94%
+rename from test/index_watcher_spec.lua
+rename to test/gitdir_watcher_spec.lua
+index 008beab..66116dc 100644
+--- a/test/index_watcher_spec.lua
++++ b/test/gitdir_watcher_spec.lua
+@@ -17,7 +17,7 @@ local get_buf_name    = helpers.curbufmeths.get_name
+--]]
+
+local DIFF_HEADER = [[^diff %-%-git ]]
+local DIFF_SIMILARITY = [[^similarity index (%d+)%%]]
+local DIFF_INDEX = [[^index (%x-)%.%.(%x-) (%d+)]]
+local DIFF_PATH_OLD = [[^%-%-%- a/(.*)]]
+local DIFF_PATH_NEW = [[^%+%+%+ b/(.*)]]
+local DIFF_HUNK_HEADER = [[^@@+ %-(%d+),(%d+) %+(%d+),(%d+) @@+]]
+
+---@class diff.Hunk
+---@field old_row integer
+---@field old_size integer
+---@field new_row integer
+---@field new_size integer
+---@field common_content string[]
+---@field old_content { [1]: integer, [2]: string[] }[]
+---@field new_content { [1]: integer, [2]: string[] }[]
+
+---@param scanner Scanner
+---@param old_row integer
+---@param old_size integer
+---@param new_row integer
+---@param new_size integer
+---@return diff.Hunk
+local function parse_diff_hunk(scanner, old_row, old_size, new_row, new_size)
+  local ret = {
+    old_row = old_row,
+    old_size = old_size,
+    new_row = new_row,
+    new_size = new_size,
+    common_content = {},
+    old_content = {},
+    new_content = {},
+  }
+
+  local common_idx, old_offset, new_offset = 1, 0, 0
+  local line = scanner:peek_line()
+  local cur_start = (line or ""):match("^([%+%- ])")
+
+  while cur_start do
+    line = scanner:next_line() --[[@as string ]]
+
+    if cur_start == " " then
+      ret.common_content[#ret.common_content + 1] = line:sub(2) or ""
+      common_idx = common_idx + 1
+
+    elseif cur_start == "-" then
+      local content = { line:sub(2) or "" }
+
+      while (scanner:peek_line() or ""):sub(1, 1) == "-" do
+        content[#content + 1] = scanner:next_line():sub(2) or ""
+      end
+
+      ret.old_content[#ret.old_content + 1] = { common_idx + old_offset, content }
+      old_offset = old_offset + #content
+
+    elseif cur_start == "+" then
+      local content = { line:sub(2) or "" }
+
+      while (scanner:peek_line() or ""):sub(1, 1) == "+" do
+        content[#content + 1] = scanner:next_line():sub(2) or ""
+      end
+
+      ret.new_content[#ret.new_content + 1] = { common_idx + new_offset, content }
+      new_offset = new_offset + #content
+    end
+
+    cur_start = (scanner:peek_line() or ""):match("^([%+%- ])")
+  end
+
+  return ret
+end
+
+---@class diff.FileEntry
+---@field renamed boolean
+---@field similarity? integer
+---@field index_old? integer
+---@field index_new? integer
+---@field mode? integer
+---@field path_old string
+---@field path_new string
+---@field hunks diff.Hunk[]
+
+---@param scanner Scanner
+---@return diff.FileEntry
+local function parse_file_diff(scanner)
+  ---@type diff.FileEntry
+  local ret = { renamed = false, hunks = {} }
+
+  -- The current line will here be the diff header
+
+  -- Renames
+  local similarity = (scanner:peek_line() or ""):match(DIFF_SIMILARITY)
+  if similarity then
+    ret.renamed = true
+    ret.similarity = tonumber(similarity) or -1
+    scanner:skip_line()
+    ret.path_old = scanner:next_line():match("^rename from (.*)")
+    ret.path_new = scanner:next_line():match("^rename to (.*)")
+  end
+
+  -- Index
+  local index_old, index_new, mode = (scanner:peek_line() or ""):match(DIFF_INDEX)
+  if index_old then
+    ret.index_old = index_old
+    ret.index_new = index_new
+    ret.mode = mode
+    scanner:next_line()
+  end
+
+  -- TODO: Handle all the extended header lines
+  -- old mode <mode>
+  -- new mode <mode>
+  -- deleted file mode <mode>
+  -- new file mode <mode>
+  -- copy from <path>
+  -- copy to <path>
+  -- rename from <path>
+  -- rename to <path>
+  -- similarity index <number>
+  -- dissimilarity index <number>
+  -- index <hash>..<hash> <mode>
+
+  -- Paths
+  local path_old = scanner:peek_line():match(DIFF_PATH_OLD)
+  if path_old then
+    if not ret.path_old then
+      ret.path_old = path_old
+      scanner:skip_line()
+      ret.path_new = scanner:next_line():match(DIFF_PATH_NEW)
+    else
+      scanner:skip_line(2)
+    end
+  end
+
+  -- Hunks
+  local line = scanner:peek_line()
+  while line and not line:match(DIFF_HEADER) do
+    local old_row, old_size, new_row, new_size = line:match(DIFF_HUNK_HEADER)
+    scanner:next_line() -- Current line is now the hunk header
+
+    if old_row then
+      table.insert(ret.hunks, parse_diff_hunk(
+        scanner,
+        tonumber(old_row) or -1,
+        tonumber(old_size) or -1,
+        tonumber(new_row) or -1,
+        tonumber(new_size) or -1
+      ))
+    end
+
+    line = scanner:peek_line()
+  end
+
+  return ret
+end
+
+---Parse a diff patch.
+---@param lines string[]
+---@return diff.FileEntry[]
+function M.parse_diff(lines)
+  local ret = {}
+  local scanner = Scanner(lines)
+
+  while scanner:peek_line() do
+    local line = scanner:next_line() --[[@as string ]]
+    -- TODO: Diff headers and patch format can take a few different forms. I.e. combined diffs
+    if line:match(DIFF_HEADER) then
+      table.insert(ret, parse_file_diff(scanner))
+    end
+  end
+
+  return ret
+end
+
+---Build either the old or the new version of a diff hunk.
+---@param hunk diff.Hunk
+---@param version "old"|"new"
+---@return string[]
+function M.diff_build_hunk(hunk, version)
+  local vcontent = version == "old" and hunk.old_content or hunk.new_content
+  local size = version == "old" and hunk.old_size or hunk.new_size
+  local common_idx = 1
+  local chunk_idx = 1
+
+  local ret = {}
+  local i = 1
+
+  while i <= size do
+    local chunk = vcontent[chunk_idx]
+
+    if chunk and chunk[1] == i then
+      for _, line in ipairs(chunk[2]) do
+        ret[#ret + 1] = line
+      end
+
+      i = i + (#chunk[2] - 1)
+      chunk_idx = chunk_idx + 1
+    else
+      ret[#ret + 1] = hunk.common_content[common_idx]
+      common_idx = common_idx + 1
+    end
+
+    i = i + 1
+  end
+
+  return ret
+end
 
 local CONFLICT_START = [[^<<<<<<< ]]
 local CONFLICT_BASE = [[^||||||| ]]

--- a/lua/diffview/vcs/utils.lua
+++ b/lua/diffview/vcs/utils.lua
@@ -267,6 +267,8 @@ local DIFF_SIMILARITY = [[^similarity index (%d+)%%]]
 local DIFF_INDEX = [[^index (%x-)%.%.(%x-) (%d+)]]
 local DIFF_PATH_OLD = [[^%-%-%- a/(.*)]]
 local DIFF_PATH_NEW = [[^%+%+%+ b/(.*)]]
+local DIFF_PATH_OLD_NULL = [[^%-%-%- (/dev/null)]]
+local DIFF_PATH_NEW_NULL = [[^%+%+%+ (/dev/null)]]
 local DIFF_HUNK_HEADER = [[^@@+ %-(%d+),(%d+) %+(%d+),(%d+) @@+]]
 
 ---@class diff.Hunk
@@ -385,11 +387,14 @@ local function parse_file_diff(scanner)
 
   -- Paths
   local path_old = scanner:peek_line():match(DIFF_PATH_OLD)
+      or scanner:peek_line():match(DIFF_PATH_OLD_NULL)
+
   if path_old then
     if not ret.path_old then
       ret.path_old = path_old
-      scanner:skip_line()
-      ret.path_new = scanner:next_line():match(DIFF_PATH_NEW)
+      scanner:skip_line(2)
+      ret.path_new = scanner:cur_line():match(DIFF_PATH_NEW)
+          or scanner:cur_line():match(DIFF_PATH_NEW_NULL)
     else
       scanner:skip_line(2)
     end


### PR DESCRIPTION
When tracing line evolution (the `-L` flag option) we look at the diff patches Git outputs in order to determine what the relevant content is. We then hide the irrelevant content by setting `foldmethod=manual` in all the diff buffers and creating custom folds derived from the hunks in the git diff.

This seems to work quite well in most cases, and makes it a lot more efficient to review changes with the `-L` flag, as we no longer need to guess where in the file the change occurred. After all, Git knows this far better than us.

Bonus change: the `scroll_view()` action now uses the window that currently has the most visible content, to scroll. This makes the scrolling far less jumpy in cases where you have a large deleted hunk. As the cursor cannot be placed inside a region of filler lines, the scroll action would previously just shoot past such regions, something that could be very disorienting. Now it will instead be able to tell that the other window has more visible content, and scroll that instead.

Also fixed the bug where `scroll_view()` with a negative number would move the cursor up one line every time it was invoked.
