### PR TITLE
docs: Explain how to jump between diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,3 +467,7 @@ git object database, and a command is echoed that shows how to undo the change.
     - (Lua): `vim.opt.fillchars:append { diff = "╱" }`
   - Note: whether or not the diagonal lines will line up nicely will depend on
     your terminal emulator. The terminal used in the screenshots is Kitty.
+- **Q: How do I jump to next diff (not next conflict)?**
+  - A: Use `[c` and `]c`
+  - `:h jumpto-diffs`
+  - more [context](https://github.com/sindrets/diffview.nvim/issues/111#issuecomment-1019902985)


### PR DESCRIPTION
Hello, very good plugin :+1:

I am starting to use it for more complex Pull Request reviews. But I was not able to easily figure out how to jump to next difference. I tried to check README for `next*` and saw `next_conflict()` and it was doing nothing for me. Only after actually reading the code I finally accepted that it was doing exactly what was the name. Nevertheless, it was the only `next_*` reference in the plugin so I did not dismiss it sooner. 

I read the whole README.md, some of the docs, keyboard mappings configuration, etc. but it took me some time to stumble upon an old issue https://github.com/sindrets/diffview.nvim/issues/111 which was exactly what I was looking for. So I decided to extend the FAQ (feel free to edit it in any way). Judging by the number of reactions on that issues other people are looking for it also.

Hopefully, it will be useful for others :slightly_smiling_face: and again thanks for a cool plugin.