### PR TITLE
fix: use correct diff layout

### DIFF
--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -135,7 +135,6 @@ function StandardView:use_entry(entry)
     layout_key = "diff4"
   end
 
-
   for _, sym in ipairs({ "a", "b", "c", "d" }) do
     if entry.layout[sym] then
       entry.layout[sym].file.winopts = vim.tbl_extend(

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -135,13 +135,15 @@ function StandardView:use_entry(entry)
     layout_key = "diff4"
   end
 
-  for _, sym in ipairs({ "a", "b", "c", "d" }) do
-    if entry.layout[sym] then
-      entry.layout[sym].file.winopts = vim.tbl_extend(
-        "force",
-        entry.layout[sym].file.winopts,
-        self.winopts[layout_key][sym] or {}
-      )
+  if layout_key then
+    for _, sym in ipairs({ "a", "b", "c", "d" }) do
+      if entry.layout[sym] then
+        entry.layout[sym].file.winopts = vim.tbl_extend(
+          "force",
+          entry.layout[sym].file.winopts,
+          self.winopts[layout_key][sym] or {}
+        )
+      end
     end
   end
 

--- a/lua/diffview/scene/views/standard/standard_view.lua
+++ b/lua/diffview/scene/views/standard/standard_view.lua
@@ -3,7 +3,7 @@ local lazy = require("diffview.lazy")
 local Diff1 = lazy.access("diffview.scene.layouts.diff_1", "Diff1") ---@type Diff1|LazyModule
 local Diff2 = lazy.access("diffview.scene.layouts.diff_2", "Diff2") ---@type Diff2|LazyModule
 local Diff3 = lazy.access("diffview.scene.layouts.diff_3", "Diff3") ---@type Diff3|LazyModule
-local Diff4 = lazy.access("diffview.scene.layouts.diff_3", "Diff4") ---@type Diff4|LazyModule
+local Diff4 = lazy.access("diffview.scene.layouts.diff_4", "Diff4") ---@type Diff4|LazyModule
 local Panel = lazy.access("diffview.ui.panel", "Panel") ---@type Panel|LazyModule
 local View = lazy.access("diffview.scene.view", "View") ---@type View|LazyModule
 local config = lazy.require("diffview.config") ---@module "diffview.config"
@@ -135,15 +135,14 @@ function StandardView:use_entry(entry)
     layout_key = "diff4"
   end
 
-  if layout_key then
-    for _, sym in ipairs({ "a", "b", "c", "d" }) do
-      if entry.layout[sym] then
-        entry.layout[sym].file.winopts = vim.tbl_extend(
-          "force",
-          entry.layout[sym].file.winopts,
-          self.winopts[layout_key][sym] or {}
-        )
-      end
+
+  for _, sym in ipairs({ "a", "b", "c", "d" }) do
+    if entry.layout[sym] then
+      entry.layout[sym].file.winopts = vim.tbl_extend(
+        "force",
+        entry.layout[sym].file.winopts,
+        self.winopts[layout_key][sym] or {}
+      )
     end
   end
 


### PR DESCRIPTION
When running `DiffviewOpen` on a merge conflict I get the following error:
``` 
The coroutine failed with this message: ...nvim/lua/diffview/scene/views/standard/s
tandard_view.lua:143: attempt to index a nil value                                                                                                                                            
stack traceback:                                                                                                                                                                              
        [C]: in function 'error'                                                                                                                                                              
        ...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:18: in function 'callback_or_next'                                                                                        
        ...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:45: in function <...share/nvim/lazy/plenary.nvim/lua/plenary/async/async.lua:44> 
```

I've bisected the repo and found 5fc2b59e9668c06588e9f0cacb79d459067ae273 to have introduced this.

Seems like the `layout_key` can be `nil` when opening the view.