### PR TITLE
fix: Workaround for `<afile>` expanding incorrectly

### DIFF
--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -23,6 +23,22 @@ end
 
 function M.init()
   local au = api.nvim_create_autocmd
+
+  -- Fix the strange behavior that "<afile>" expands non-files
+  -- as file name in some cases.
+  --
+  -- About more information please checkout:
+  --  * sindrets/diffview.nvim#369
+  --  * neovim/neovim#23943
+  local fetch_tabnr = function (state)
+    if vim.fn.has("nvim-0.9.2") ~= 1 then
+      return tonumber(state.match)
+    else
+      return tonumber(state.file)
+    end
+  end
+
+  -- Set up highlighting
   hl.setup()
 
   -- Set up autocommands
@@ -45,7 +61,7 @@ function M.init()
     group = M.augroup,
     pattern = "*",
     callback = function(state)
-      M.close(tonumber(state.file))
+      M.close(fetch_tabnr(state))
     end,
   })
   au("BufWritePost", {
@@ -59,7 +75,7 @@ function M.init()
     group = M.augroup,
     pattern = "*",
     callback = function(state)
-      M.emit("win_closed", tonumber(state.file))
+      M.emit("win_closed", fetch_tabnr(state))
     end,
   })
   au("ColorScheme", {

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -22,21 +22,21 @@ function M.setup(user_config)
 end
 
 function M.init()
-  local au = api.nvim_create_autocmd
-
   -- Fix the strange behavior that "<afile>" expands non-files
   -- as file name in some cases.
   --
-  -- About more information please checkout:
+  -- Ref:
   --  * sindrets/diffview.nvim#369
   --  * neovim/neovim#23943
-  local fetch_tabnr = function (state)
+  local function get_tabnr(state)
     if vim.fn.has("nvim-0.9.2") ~= 1 then
       return tonumber(state.match)
     else
       return tonumber(state.file)
     end
   end
+
+  local au = api.nvim_create_autocmd
 
   -- Set up highlighting
   hl.setup()
@@ -61,7 +61,7 @@ function M.init()
     group = M.augroup,
     pattern = "*",
     callback = function(state)
-      M.close(fetch_tabnr(state))
+      M.close(get_tabnr(state))
     end,
   })
   au("BufWritePost", {
@@ -75,7 +75,7 @@ function M.init()
     group = M.augroup,
     pattern = "*",
     callback = function(state)
-      M.emit("win_closed", fetch_tabnr(state))
+      M.emit("win_closed", get_tabnr(state))
     end,
   })
   au("ColorScheme", {


### PR DESCRIPTION
Resolves #369.

I have left some question here:

1. Added a comment not related to this pr, sorry if this makes you uncomfortable I will restore it.

2. I'm not sure if the fetch_tabnr's *name* is correct.

3. I'm not sure if fetch_tabnr is in the right place for this, I tried to throw it into *utils* but its logic is not that common.