### PR TITLE
feat: support `--walk-reflogs` for DiffviewFileHistory

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -296,6 +296,13 @@ COMMANDS                                        *diffview-commands*
                 YYYY-mm-dd, YYYY-mm-dd HH:mm:ss, or natural language (for
                 instance "2 weeks 6 hours 12 minutes ago")
 
+        -g, --walk-reflogs
+               Instead of walking the commit ancestry chain, walk reflog
+               entries from the most recent one to older ones. When this
+               option is used you cannot specify commits to exclude (that is,
+               ^commit, commit1..commit2, and commit1...commit2 notations
+               cannot be used).
+
     Mercurial Options: ~
 
         --rev={rev}

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -276,6 +276,7 @@ M._config = M.defaults
 ---@field path_args string[]
 ---@field after string
 ---@field before string
+---@field g boolean
 
 ---@class HgLogOptions
 ---@field follow string
@@ -316,6 +317,7 @@ M.log_option_defaults = {
     G = nil,
     S = nil,
     path_args = {},
+    g = false,
   },
   ---@type HgLogOptions
   hg = {

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -400,7 +400,8 @@ function GitAdapter:prepare_fh_options(log_options, single_file)
       o.G and { "-E", "-G" .. o.G } or nil,
       o.S and { "-S" .. o.S, "--pickaxe-regex" } or nil,
       o.after and { "--after=" .. o.after } or nil,
-      o.before and { "--before=" .. o.before } or nil
+      o.before and { "--before=" .. o.before } or nil,
+      o.g and { "-g" } or nil
     )
   }
 end
@@ -786,6 +787,7 @@ function GitAdapter:file_history_options(range, paths, argo)
     { "S" },
     { "after", "since" },
     { "before", "until" },
+    { "g", "walk-reflogs" },
   }
 
   local log_options = { rev_range = range_arg } --[[@as GitLogOptions ]]
@@ -807,6 +809,10 @@ function GitAdapter:file_history_options(range, paths, argo)
 
   if log_options.L and next(log_options.L) then
     log_options.follow = false -- '--follow' is not compatible with '-L'
+  end
+
+  if log_options.g then
+      log_options.reverse = false -- '--reverse' is not compatible with '--walk-reflogs'
   end
 
   log_options.path_args = paths


### PR DESCRIPTION
feat: support 'git log -g'

add support for `-g, --walk-reflogs` flag for the `:DiffviewFileHistory` command

Fixes https://github.com/sindrets/diffview.nvim/issues/353

```
$ git stash list
stash@{0}: WIP on feat/walk-reflogs: 334008a chore: add documentation for new options
stash@{1}: WIP on feat/walk-reflogs: 334008a chore: add documentation for new options
```
Before:
![image](https://github.com/sindrets/diffview.nvim/assets/21695295/9c8544e8-a50c-42d4-9f7c-a824be7be133)

After:
![image](https://github.com/sindrets/diffview.nvim/assets/21695295/d8185f7b-0977-46a0-9e73-830d6b30a54c)
