### PR TITLE
feat: remove bottom extra blank line in file panel

### DIFF
--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -508,6 +508,10 @@ function M.render(bufid, data)
     hl_data = { data.hl }
   end
 
+  if #lines > 0 and lines[#lines] == '' then
+    table.remove(lines)
+  end
+
   api.nvim_buf_set_lines(bufid, 0, -1, false, lines)
   api.nvim_buf_clear_namespace(bufid, data.namespace, 0, -1)
   for _, t in ipairs(hl_data) do


### PR DESCRIPTION
In Diffview panel, Press command `G`, it'is jump to bottom line, which is a empty line.

![image](https://github.com/sindrets/diffview.nvim/assets/16932133/34cc19c7-012c-4337-83d5-9666365425d4)
