### PR TITLE
docs: Add commit example using `vim.ui.input()`

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -208,6 +208,9 @@ keymaps = {
 
 This will popup a simple input box for your to enter the commit msg and commit
 
+![show](https://github.com/LintaoAmons/diffview.nvim/assets/95092244/db0d2ed5-7f9c-436a-b627-0e8cc34ba48b)
+
+
 ```lua
 keymaps = {
           file_panel = {

--- a/USAGE.md
+++ b/USAGE.md
@@ -204,6 +204,40 @@ keymaps = {
 }
 ```
 
+### Use `vim.ui.input`
+
+This will popup a simple input box for your to enter the commit msg and commit
+
+```lua
+keymaps = {
+          file_panel = {
+            {
+              "n", "c",
+              function()
+                vim.ui.input({ prompt = "Commit msg: " }, function(msg)
+                  local Job = require("plenary.job")
+                  local stderr = {}
+                  Job:new({
+                    command = "git",
+                    args = { "commit", "-m", msg },
+                    cwd = ".",
+                    on_stderr = function(_, data)
+                      table.insert(stderr, data)
+                    end,
+                  }):sync()
+                  if #stderr == 0 then
+                    vim.api.nvim_command("tabclose")
+                  else
+                    vim.print(stderr[1])
+                  end
+                end)
+              end,
+              { desc = "git commit" },
+            },
+          },
+        }
+```
+
 ### Use `:!cmd`
 
 If you only ever write simple commit messages you could make use of `:h !cmd`:


### PR DESCRIPTION
A more intuitive way of commit. Just one keystroke after stash right in diffview

![show](https://github.com/LintaoAmons/diffview.nvim/assets/95092244/db0d2ed5-7f9c-436a-b627-0e8cc34ba48b)