### PR TITLE
fix(git): fix data access if nil

### DIFF
--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -525,7 +525,7 @@ function GitAdapter:stream_fh_data(state)
       end
 
       data = {}
-    else
+    elseif data then
       data[#data + 1] = line
     end
   end
@@ -604,7 +604,7 @@ function GitAdapter:stream_line_trace_data(state)
       end
 
       data = {}
-    else
+    elseif data then
       data[#data + 1] = line
     end
   end


### PR DESCRIPTION
I had an error while using `DiffViewFileHistory` with nvim nightly v0.10.0-dev-2361+ga376d979b

The command now works as expected.
