### PR TITLE
fix: cancel update if view becomes out of focus

### DIFF
--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -20,6 +20,7 @@ return function(view)
       end
 
       if view.ready then
+        view:rerender()
         view:update_files()
       end
     end,

--- a/lua/diffview/scene/views/diff/listeners.lua
+++ b/lua/diffview/scene/views/diff/listeners.lua
@@ -20,7 +20,6 @@ return function(view)
       end
 
       if view.ready then
-        view:rerender()
         view:update_files()
       end
     end,


### PR DESCRIPTION
Fixes #462.

I work in a large monorepo and noticed that when :DiffviewOpen was used, and you switched to another tab, you would switch back to the Diffview window.

Reason for this being that inside the async function `DiffView:update_file()`, it is possible for the line `local err, new_files = await(self:get_updated_files())` to take a long amount of time in large git repos. This meant it's possible for a user to switch to another tab prior to the async function completing, in which at the end of the function the user's window is switched to the DiffView.

I'm not entirely familiar with Lua but I made a very rough PR that changes the order of when re-rendering the panels work to abate this issue.