### PR TITLE
feat: auto close buffer opened by diff_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ require("diffview").setup({
   use_icons = true,         -- Requires nvim-web-devicons
   show_help_hints = true,   -- Show hints for how to open the help panel
   watch_index = true,       -- Update views and index buffers when the git index changes.
+  delete_buffer_on_diff_exit = false, -- Delete file buffers opened by diffview that were not opened
   icons = {                 -- Only applies when use_icons is true.
     folder_closed = "",
     folder_open = "",

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -10,6 +10,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
     use_icons = true,         -- Requires nvim-web-devicons
     show_help_hints = true,   -- Show hints for how to open the help panel
     watch_index = true,       -- Update views and index buffers when the git index changes.
+    delete_buffer_on_diff_exit = false, -- Delete file buffers opened by diffview that were not opened
     icons = {                 -- Only applies when use_icons is true.
       folder_closed = "",
       folder_open = "",

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -42,6 +42,7 @@ M.defaults = {
   use_icons = true,
   show_help_hints = true,
   watch_index = true,
+  delete_buffer_on_diff_exit = false,
   icons = {
     folder_closed = "",
     folder_open = "",

--- a/lua/diffview/scene/view.lua
+++ b/lua/diffview/scene/view.lua
@@ -38,6 +38,9 @@ function View:init_layout() oop.abstract_stub() end
 ---@abstract
 function View:post_open() oop.abstract_stub() end
 
+---@abstract
+function View:pre_open() oop.abstract_stub() end
+
 ---@diagnostic enable unused-local
 
 ---View constructor
@@ -62,6 +65,7 @@ function View:init(opt)
 end
 
 function View:open()
+  self:pre_open()
   vim.cmd("tab split")
   self.tabpage = api.nvim_get_current_tabpage()
   self:init_layout()

--- a/lua/diffview/scene/views/diff/diff_view.lua
+++ b/lua/diffview/scene/views/diff/diff_view.lua
@@ -77,6 +77,11 @@ function DiffView:init(opt)
   self.attached_bufs = {}
   self.emitter:on("file_open_post", utils.bind(self.file_open_post, self))
   self.valid = true
+  self.buffers_pre_open = {}
+end
+
+function DiffView:pre_open()
+    self.buffers_pre_open = vim.api.nvim_list_bufs()
 end
 
 function DiffView:post_open()
@@ -170,6 +175,16 @@ end
 
 ---@override
 function DiffView:close()
+  if config.get_config().delete_buffer_on_diff_exit then
+    -- delete buffers that were opened by the view
+    local buffers_pre_close = vim.api.nvim_list_bufs()
+    for _, buf in ipairs(buffers_pre_close) do
+      if not vim.tbl_contains(self.buffers_pre_open, buf) then
+        vim.api.nvim_buf_delete(buf, { force = false})
+      end
+    end
+  end
+  
   if not self.closing:check() then
     self.closing:send()
 

--- a/lua/diffview/scene/views/file_history/file_history_view.lua
+++ b/lua/diffview/scene/views/file_history/file_history_view.lua
@@ -39,6 +39,9 @@ function FileHistoryView:init(opt)
   self.valid = true
 end
 
+function FileHistoryView:pre_open()
+end
+
 function FileHistoryView:post_open()
   self.commit_log_panel = CommitLogPanel(self.adapter, {
     name = ("diffview://%s/log/%d/%s"):format(self.adapter.ctx.dir, self.tabpage, "commit_log"),


### PR DESCRIPTION
By setting `delete_buffer_on_diff_exit` in config, diff_view automatically closes all buffers opened as a result of previewing diff. I found myself checking the diffs a lot, that ends up adding a lot of buffers that clutters up my buffer line.

Buffers that are already opened before opening diff view aren't affected.