### PR TITLE
fix(git): add `--no-exclude-standard` when detecting binary

### DIFF
--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -1906,6 +1906,7 @@ function GitAdapter:is_binary(path, rev)
   local cmd = { "-c", "submodule.recurse=false", "grep", "-I", "--name-only", "-e", "." }
   if rev.type == RevType.LOCAL then
     cmd[#cmd+1] = "--untracked"
+    cmd[#cmd+2] = "--no-exclude-standard"
   elseif rev.type == RevType.STAGE then
     cmd[#cmd+1] = "--cached"
   else

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -1906,7 +1906,7 @@ function GitAdapter:is_binary(path, rev)
   local cmd = { "-c", "submodule.recurse=false", "grep", "-I", "--name-only", "-e", "." }
   if rev.type == RevType.LOCAL then
     cmd[#cmd+1] = "--untracked"
-    cmd[#cmd+2] = "--no-exclude-standard"
+    cmd[#cmd+1] = "--no-exclude-standard"
   elseif rev.type == RevType.STAGE then
     cmd[#cmd+1] = "--cached"
   else


### PR DESCRIPTION
Otherwise, files that was included in gitignore (but added via `git add --force`) will be treated as binary and not showing diff.