### PR TITLE
fix: replace deprecated table operations for neovim v0.10

### DIFF
--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -18,10 +18,10 @@ M.views = {}
 
 function M.diffview_open(args)
   local default_args = config.get_config().default_args.DiffviewOpen
-  local argo = arg_parser.parse(vim.tbl_flatten({ default_args, args }))
+  local argo = arg_parser.parse(utils.flatten({ default_args, args }))
   local rev_arg = argo.args[1]
 
-  logger:info("[command call] :DiffviewOpen " .. table.concat(vim.tbl_flatten({
+  logger:info("[command call] :DiffviewOpen " .. table.concat(utils.flatten({
     default_args,
     args,
   }), " "))
@@ -69,9 +69,9 @@ end
 ---@param args string[]
 function M.file_history(range, args)
   local default_args = config.get_config().default_args.DiffviewFileHistory
-  local argo = arg_parser.parse(vim.tbl_flatten({ default_args, args }))
+  local argo = arg_parser.parse(utils.flatten({ default_args, args }))
 
-  logger:info("[command call] :DiffviewFileHistory " .. table.concat(vim.tbl_flatten({
+  logger:info("[command call] :DiffviewFileHistory " .. table.concat(utils.flatten({
     default_args,
     args,
   }), " "))

--- a/lua/diffview/logger.lua
+++ b/lua/diffview/logger.lua
@@ -174,7 +174,7 @@ function Logger.dstring(object)
 
     if mt and mt.__tostring then
       return tostring(object)
-    elseif vim.tbl_islist(object) then
+    elseif utils.islist(object) then
       if #object == 0 then return "[]" end
       local s = ""
 

--- a/lua/diffview/multi_job.lua
+++ b/lua/diffview/multi_job.lua
@@ -217,7 +217,7 @@ end
 
 ---@return string[]
 function MultiJob:stdout()
-  return vim.tbl_flatten(
+  return utils.flatten(
     ---@param value diffview.Job
     vim.tbl_map(function(value)
       return value.stdout
@@ -227,7 +227,7 @@ end
 
 ---@return string[]
 function MultiJob:stderr()
-  return vim.tbl_flatten(
+  return utils.flatten(
     ---@param value diffview.Job
     vim.tbl_map(function(value)
       return value.stderr

--- a/lua/diffview/stream.lua
+++ b/lua/diffview/stream.lua
@@ -33,7 +33,7 @@ end
 ---@param src table|function
 function Stream:create_src(src)
   if type(src) == "table" then
-    if vim.tbl_islist(src) then
+    if utils.islist(src) then
       local itr = ipairs(src)
 
       return function()

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -1347,7 +1347,7 @@ end
 M.islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist ---@diagnostic disable-line: deprecated
 
 M.flatten = vim.fn.has("nvim-0.10") == 1 and function(...)
-  return vim.iter(...):flatten():totable()
+  return vim.iter(...):flatten(math.huge):totable() 
 end or vim.tbl_flatten ---@diagnostic disable-line: deprecated
 
 M.path_sep = path_sep

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -1344,7 +1344,11 @@ function M.merge_sort(t, comparator)
   split_merge(t, 1, #t, comparator)
 end
 
-M.islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
+M.islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist ---@diagnostic disable-line: deprecated
+
+M.flatten = vim.fn.has("nvim-0.10") == 1 and function(...)
+  return vim.iter(...):flatten():totable()
+end or vim.tbl_flatten ---@diagnostic disable-line: deprecated
 
 M.path_sep = path_sep
 

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -1344,11 +1344,31 @@ function M.merge_sort(t, comparator)
   split_merge(t, 1, #t, comparator)
 end
 
-M.islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist ---@diagnostic disable-line: deprecated
+--- @diagnostic disable-next-line: deprecated
+M.islist = vim.fn.has("nvim-0.10") == 1 and vim.islist or vim.tbl_islist
 
-M.flatten = vim.fn.has("nvim-0.10") == 1 and function(...)
-  return vim.iter(...):flatten(math.huge):totable() 
-end or vim.tbl_flatten ---@diagnostic disable-line: deprecated
+--- @param t table
+--- @return any[]
+function M.flatten(t)
+  local result = {}
+
+  --- @param _t table<any,any>
+  local function recurse(_t)
+    local n = #_t
+    for i = 1, n do
+      local v = _t[i]
+      if type(v) == 'table' then
+        recurse(v)
+      elseif v then
+        table.insert(result, v)
+      end
+    end
+  end
+
+  recurse(t)
+
+  return result
+end
 
 M.path_sep = path_sep
 

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -1344,6 +1344,8 @@ function M.merge_sort(t, comparator)
   split_merge(t, 1, #t, comparator)
 end
 
+M.islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
+
 M.path_sep = path_sep
 
 --- @param t table

--- a/lua/diffview/vcs/adapter.lua
+++ b/lua/diffview/vcs/adapter.lua
@@ -154,7 +154,7 @@ end
 function VCSAdapter:exec_sync(args, cwd_or_opt)
   if not self.class.bootstrap.done then self.class.run_bootstrap() end
 
-  local cmd = vim.tbl_flatten({ self:get_command(), args })
+  local cmd = utils.flatten({ self:get_command(), args })
 
   if not self.class.bootstrap.ok then
     logger:error(

--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -98,7 +98,7 @@ function GitAdapter.run_bootstrap()
     return err(fmt("Configured `git_cmd` is not executable: '%s'", git_cmd[1]))
   end
 
-  local out = utils.job(vim.tbl_flatten({ git_cmd, "version" }))
+  local out = utils.job(utils.flatten({ git_cmd, "version" }))
   bs.version_string = out[1] and out[1]:match("git version (%S+)") or nil
 
   if not bs.version_string then
@@ -170,7 +170,7 @@ end
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
-  local out, code = utils.job(vim.tbl_flatten({
+  local out, code = utils.job(utils.flatten({
     config.get_config().git_cmd,
     { "rev-parse", "--path-format=absolute", "--show-toplevel" },
   }), path)

--- a/lua/diffview/vcs/adapters/hg/init.lua
+++ b/lua/diffview/vcs/adapters/hg/init.lua
@@ -58,7 +58,7 @@ function HgAdapter.run_bootstrap()
     return err(fmt("Configured `hg_cmd` is not executable: '%s'", hg_cmd[1]))
   end
 
-  local out = utils.job(vim.tbl_flatten({ hg_cmd, "version" }))
+  local out = utils.job(utils.flatten({ hg_cmd, "version" }))
   local version = out[1] and out[1]:match("Mercurial .*%(version (%S*)%)") or nil
   if not version then
     return err("Could not get Mercurial version!")
@@ -127,7 +127,7 @@ end
 ---@param path string
 ---@return string?
 local function get_toplevel(path)
-  local out, code = utils.job(vim.tbl_flatten({config.get_config().hg_cmd, {"root"}}), path)
+  local out, code = utils.job(utils.flatten({config.get_config().hg_cmd, {"root"}}), path)
   if code ~= 0 then
     return nil
   end


### PR DESCRIPTION
Resolves #488.

Neovim nightly deprecated some table operations resulting in diffview.nvim crashes. I've moved the operations `islist` and `flatten` to the utils package so that we can apply the appropriate function depending on the Neovim version.

Please let me know what you think, thanks!