### PR TITLE
Stage/Working Color highlight in FilePanel

### DIFF
--- a/lua/diffview/scene/views/diff/render.lua
+++ b/lua/diffview/scene/views/diff/render.lua
@@ -169,7 +169,7 @@ return function(panel)
   -- sections.
   if #panel.files.working > 0 or not has_other_files then
     comp = panel.components.working.title.comp
-    comp:add_text("Changes ", "DiffviewFilePanelTitle")
+    comp:add_text("Changes ", "DiffviewFilePanelTitleWorking")
     comp:add_text("(" .. #panel.files.working .. ")", "DiffviewFilePanelCounter")
     comp:ln()
 
@@ -179,7 +179,7 @@ return function(panel)
 
   if #panel.files.staged > 0 then
     comp = panel.components.staged.title.comp
-    comp:add_text("Staged changes ", "DiffviewFilePanelTitle")
+    comp:add_text("Staged changes ", "DiffviewFilePanelTitleStaged")
     comp:add_text("(" .. #panel.files.staged .. ")", "DiffviewFilePanelCounter")
     comp:ln()
 


### PR DESCRIPTION
Hello,

I really like your plugin, it's straightforward and exactly what I was looking for my git integration.

I have one minor annoyance : I don't like that "Changes" and "Staged changes" appear with the same highlight. It confused me a few time when one of the two list isn't present, I would find clearer something green-ish for the Staged changes.

![image](https://github.com/sindrets/diffview.nvim/assets/7933289/809fb1e2-7c22-4bfc-8b3d-f2194e5f5f77)

I thought I could just come up with a `hi link` of sorts, but since it's the same hl group for both, there is not much I could do without changing the DiffView source.

The current Pull Request is just a first step to show what I'm talking about. It would allows for colors scheme implementer (or myself in my config) to tweak the color of each Title afterwards.
My plan was to give a specific name for each Title, and then link all theses to a generic name, so that it doesn't break any existing behavior, or something alike.
However, my understanding of the `hi link` conventions is quite limited, and I couldn't figure how the `DiffviewFilePanelTitle` hl group even ends up being red in my config. I tested with a few colorschemes, and the titles would have different colors, without me being able to get how this ends up to be.

If somebody would be able to point me in the right direction, I would be very grateful to learn something and elaborate on the PR.

Also, feel free to close this issue if you consider that it's too minor to be worth the effort.
All the best and thanks for the great work