### PR TITLE
Updated islist for Neovim 0.12+

### DIFF
--- a/lua/diffview/hl.lua
+++ b/lua/diffview/hl.lua
@@ -114,8 +114,8 @@ if HAS_NVIM_0_8 then
   }
 end
 
-vim.tbl_add_reverse_lookup(M.HlAttribute)
-vim.tbl_add_reverse_lookup(style_attrs)
+utils.tbl_add_reverse_lookup(M.HlAttribute)
+utils.tbl_add_reverse_lookup(style_attrs)
 local hlattr = M.HlAttribute
 
 ---@param name string Syntax group name.
@@ -242,7 +242,7 @@ function M.hi_spec_to_def_map(spec)
   end
 
   if spec.style then
-    local spec_attrs = vim.tbl_add_reverse_lookup(vim.split(spec.style, ","))
+    local spec_attrs = utils.tbl_add_reverse_lookup(vim.split(spec.style, ","))
 
     for _, attr in ipairs(style_attrs) do
       res[attr] = spec_attrs[attr] ~= nil

--- a/lua/diffview/lib.lua
+++ b/lua/diffview/lib.lua
@@ -199,7 +199,7 @@ end
 ---@return boolean
 function M.is_buf_in_use(bufnr, ignore)
   local ignore_map = ignore and utils.vec_slice(ignore) or {}
-  vim.tbl_add_reverse_lookup(ignore_map)
+  utils.tbl_add_reverse_lookup(ignore_map)
 
   for _, view in ipairs(M.views) do
     if view:instanceof(StandardView.__get()) then

--- a/lua/diffview/logger.lua
+++ b/lua/diffview/logger.lua
@@ -174,7 +174,7 @@ function Logger.dstring(object)
 
     if mt and mt.__tostring then
       return tostring(object)
-    elseif vim.tbl_islist(object) then
+    elseif utils.islist(object) then
       if #object == 0 then return "[]" end
       local s = ""
 

--- a/lua/diffview/oop.lua
+++ b/lua/diffview/oop.lua
@@ -1,4 +1,6 @@
 local fmt = string.format
+local lazy = require("diffview.lazy")
+local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
 local M = {}
 
@@ -10,7 +12,7 @@ end
 ---@param t T
 ---@return T
 function M.enum(t)
-  vim.tbl_add_reverse_lookup(t)
+  utils.tbl_add_reverse_lookup(t)
   return t
 end
 

--- a/lua/diffview/stream.lua
+++ b/lua/diffview/stream.lua
@@ -33,7 +33,7 @@ end
 ---@param src table|function
 function Stream:create_src(src)
   if type(src) == "table" then
-    if vim.tbl_islist(src) then
+    if utils.islist(src) then
       local itr = ipairs(src)
 
       return function()

--- a/lua/diffview/utils.lua
+++ b/lua/diffview/utils.lua
@@ -9,6 +9,9 @@ local logger = DiffviewGlobal.logger
 
 local M = {}
 
+-- NOTE: This can be changed to `vim.islist` after Neovim 0.9 support is dropped
+M.islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
+
 ---@class vector<T> : { [integer]: T }
 ---@alias falsy false|nil
 ---@alias truthy true|number|string|table|function|thread|userdata
@@ -544,6 +547,19 @@ function M.tbl_access(t, table_path)
   end
 
   return cur
+end
+
+---Modify `data` so every key is also a value and every value is also a key.
+---Note: This function both modifies `data` and returns it, for compatibility reasons.
+---@param data table<..., ...> Any data to reverse and append onto itself.
+---@return table<..., ...> # The final modified data.
+---
+function M.tbl_add_reverse_lookup(data)
+  for key, value in pairs(data) do
+    data[value] = key
+  end
+
+  return data
 end
 
 ---Deep extend a table, and also perform a union on all sub-tables.


### PR DESCRIPTION
Fixes these deprecation warnings in Neovim 0.10+

```
vim.tbl_add_reverse_lookup is deprecated. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
        vim/shared.lua: in function 'tbl_add_reverse_lookup'
        ...l/.config/nvim/bundle/diffview.nvim/lua/diffview/oop.lua:13: in function 'enum'
        ...config/nvim/bundle/diffview.nvim/lua/diffview/logger.lua:101: in main chunk
        [C]: in function 'require'
        .../.config/nvim/bundle/diffview.nvim/lua/diffview/lazy.lua:77: in function 'handler'
        .../.config/nvim/bundle/diffview.nvim/lua/diffview/lazy.lua:23: in function '__get'
        .../.config/nvim/bundle/diffview.nvim/lua/diffview/lazy.lua:44: in function 'Logger'
        ...fig/nvim/bundle/diffview.nvim/lua/diffview/bootstrap.lua:48: in main chunk
        [C]: in function 'require'
        ...al/.config/nvim/bundle/diffview.nvim/plugin/diffview.lua:1: in main chunk
        ...
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:485: in function <...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:484>
        [C]: in function 'xpcall'
        .../.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:113: in function 'try'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:484: in function 'source'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:443: in function 'source_runtime'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:411: in function 'packadd'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:346: in function '_load'
        ...local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:191: in function 'load'
        .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:10: in function '_load'
        .../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:34: in function <.../share/nvim/lazy/lazy.nvim/lua/lazy/core/handler/cmd.lua:16>
vim.tbl_islist is deprecated, use vim.islist instead. :help deprecated
Feature will be removed in Nvim 0.12
stack traceback:
        vim/shared.lua: in function 'tbl_islist'
        ...config/nvim/bundle/diffview.nvim/lua/diffview/logger.lua:177: in function 'dstring'
        ....config/nvim/bundle/diffview.nvim/lua/diffview/async.lua:291: in function 'await'
        ...l/.config/nvim/bundle/diffview.nvim/lua/diffview/job.lua:477: in function <...l/.config/nvim/bundle/diffview.nvim/lua/diffview/job.lua:466>
        [C]: in function 'xpcall'
        ....config/nvim/bundle/diffview.nvim/lua/diffview/async.lua:361: in function <....config/nvim/bundle/diffview.nvim/lua/diffview/async.lua:358>
```