### PR TITLE
feat: Add `DiffviewToggle` command

### DIFF
--- a/doc/diffview.txt
+++ b/doc/diffview.txt
@@ -18,12 +18,12 @@ for any git rev.
 
 USAGE                                           *diffview-usage*
 
-Quick-start: `:DiffviewOpen` to open a Diffview that compares against the
+Quick-start: `:DiffviewOpen` or `:DiffviewToggle` to open a Diffview that compares against the
 index.
 
 You can have multiple Diffviews open, tracking different git revs. Each Diffview
-opens in its own tabpage. To close and dispose of a Diffview, call either
-`:DiffviewClose` or `:tabclose` while a Diffview is the current tabpage.
+opens in its own tabpage. To close and dispose of a Diffview, call
+`:DiffviewClose`, `:DiffviewToggle` or `:tabclose` while a Diffview is the current tabpage.
 Diffviews are automatically updated:
 
         • Every time you enter a Diffview
@@ -369,6 +369,13 @@ COMMANDS                                        *diffview-commands*
 
                                                 *:DiffviewClose*
 :DiffviewClose          Close the active Diffview.
+
+                                                *:DiffviewToggle*
+:DiffviewToggle [git-rev] [options] [ -- {paths...}]
+
+       Alias for `:DiffviewOpen` when the current tabpage is not a Diffview,
+       otherwise acts as an alias for `:DiffviewClose`. Accepts the same
+       arguments as `:DiffviewOpen`.
 
                                                 *:DiffviewToggleFiles*
 :DiffviewToggleFiles    Toggles the file panel.

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -133,6 +133,7 @@ function M.open(args)
   end
 end
 
+
 ---@param range? { [1]: integer, [2]: integer }
 ---@param args string[]
 function M.file_history(range, args)
@@ -154,6 +155,16 @@ function M.close(tabpage)
   if view then
     view:close()
     lib.dispose_view(view)
+  end
+end
+
+-- @param args string[]
+function M.toggle(args)
+  local view = lib.get_current_view()
+  if view then
+    M.close()
+  else
+    M.open(args)
   end
 end
 

--- a/lua/diffview/init.lua
+++ b/lua/diffview/init.lua
@@ -133,7 +133,6 @@ function M.open(args)
   end
 end
 
-
 ---@param range? { [1]: integer, [2]: integer }
 ---@param args string[]
 function M.file_history(range, args)

--- a/plugin/diffview.lua
+++ b/plugin/diffview.lua
@@ -24,6 +24,10 @@ command("DiffviewOpen", function(ctx)
   diffview.open(arg_parser.scan(ctx.args).args)
 end, { nargs = "*", complete = completion })
 
+command("DiffviewToggle", function(ctx)
+  diffview.toggle(arg_parser.scan(ctx.args).args)
+end, { nargs = "*", complete = completion })
+
 command("DiffviewFileHistory", function(ctx)
   local range
 


### PR DESCRIPTION
adds `DiffviewToggle` command that acts as an alias to either `DiffviewOpen` or `DiffviewClose` depending on if the current tabpage is a diffview or not