### PR TITLE
fix: only replace path with env var if value defined

### DIFF
--- a/lua/diffview/path.lua
+++ b/lua/diffview/path.lua
@@ -295,8 +295,8 @@ function PathLib:expand(path)
 
   for i = idx, #segments do
     local env_var = segments[i]:match("^%$(%S+)$")
-    if env_var then
-      segments[i] = uv.os_getenv(env_var) or env_var
+    if env_var and uv.os_getenv(env_var) ~= nil then
+      segments[i] = uv.os_getenv(env_var)
     end
   end
 

--- a/lua/diffview/tests/functional/pathlib_spec.lua
+++ b/lua/diffview/tests/functional/pathlib_spec.lua
@@ -248,7 +248,7 @@ describe("diffview.path", function()
       local pl = PathLib({ os = "unix" })
 
       eq("/lorem/ipsum/dolor/foo", pl:expand("~/foo"))
-      eq("foo/EXPANDED_FOO/EXPANDED_BAR/baz", pl:expand("foo/$VAR_FOO/$VAR_BAR/baz"))
+      eq("foo/EXPANDED_FOO/EXPANDED_BAR/$baz", pl:expand("foo/$VAR_FOO/$VAR_BAR/$baz"))
     end)
   end)
 


### PR DESCRIPTION
fixes https://github.com/sindrets/diffview.nvim/issues/556

The code in question is trying to replace an environment variable name in a file path with it's value. It is assuming that if a segment starts with `$` then it is an environment variable name. There are frontend frameworks with file-based routing that use `$` to indicate a value in a path (ie https://tanstack.com/router/latest/docs/framework/react/guide/file-based-routing). We need to strip the `$` off of the name to pass to `os_getenv` but If there isn't a value for the environment variable, we shouldn't remove the `$` from the path since this is a valid file and directory name.