### PR TITLE
Add unified diff layout

### DIFF
--- a/doc/diffview_changelog.txt
+++ b/doc/diffview_changelog.txt
@@ -5,6 +5,24 @@ CHANGELOG
 
 NOTE: This changelog only encompasses breaking changes.
 
+                                                *diffview.changelog-unified*
+
+Added new unified diff layout ("diff_unified") that shows only the working copy
+of a file in a single panel, making it similar to how unified diffs appear in other
+tools. To use it, set the layout in your config:
+
+```lua
+require("diffview").setup({
+  view = {
+    default = {
+      layout = "diff_unified",
+    },
+  },
+})
+```
+
+Or cycle to it using the default keybinding `g<C-x>`.
+
                                                 *diffview.changelog-271*
 
 PR: https://github.com/sindrets/diffview.nvim/pull/271

--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -25,6 +25,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
       --  'diff1_plain'
       --    |'diff2_horizontal'
       --    |'diff2_vertical'
+      --    |'diff_unified'
       --    |'diff3_horizontal'
       --    |'diff3_vertical'
       --    |'diff3_mixed'

--- a/lua/diffview/actions.lua
+++ b/lua/diffview/actions.lua
@@ -14,6 +14,7 @@ local vcs_utils = lazy.require("diffview.vcs.utils") ---@module "diffview.vcs.ut
 local Diff1 = lazy.access("diffview.scene.layouts.diff_1", "Diff1") ---@type Diff1|LazyModule
 local Diff2Hor = lazy.access("diffview.scene.layouts.diff_2_hor", "Diff2Hor") ---@type Diff2Hor|LazyModule
 local Diff2Ver = lazy.access("diffview.scene.layouts.diff_2_ver", "Diff2Ver") ---@type Diff2Ver|LazyModule
+local DiffUnified = lazy.access("diffview.scene.layouts.diff_unified", "DiffUnified") ---@type DiffUnified|LazyModule
 local Diff3 = lazy.access("diffview.scene.layouts.diff_3", "Diff3") ---@type Diff3|LazyModule
 local Diff3Hor = lazy.access("diffview.scene.layouts.diff_3_hor", "Diff3Hor") ---@type Diff3Hor|LazyModule
 local Diff3Ver = lazy.access("diffview.scene.layouts.diff_3_ver", "Diff3Ver") ---@type Diff3Hor|LazyModule
@@ -494,6 +495,7 @@ function M.cycle_layout()
     standard = {
       Diff2Hor.__get(),
       Diff2Ver.__get(),
+      DiffUnified.__get(),
     },
     merge_tool = {
       Diff3Hor.__get(),

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -15,6 +15,7 @@ local Diff3Mixed = lazy.access("diffview.scene.layouts.diff_3_mixed", "Diff3Mixe
 local Diff3Ver = lazy.access("diffview.scene.layouts.diff_3_ver", "Diff3Ver") ---@type Diff3Hor|LazyModule
 local Diff4 = lazy.access("diffview.scene.layouts.diff_4", "Diff4") ---@type Diff4|LazyModule
 local Diff4Mixed = lazy.access("diffview.scene.layouts.diff_4_mixed", "Diff4Mixed") ---@type Diff4Mixed|LazyModule
+local DiffUnified = lazy.access("diffview.scene.layouts.diff_unified", "DiffUnified") ---@type DiffUnified|LazyModule
 local utils = lazy.require("diffview.utils") ---@module "diffview.utils"
 
 local M = {}
@@ -380,6 +381,7 @@ end
 ---@alias LayoutName "diff1_plain"
 ---       | "diff2_horizontal"
 ---       | "diff2_vertical"
+---       | "diff_unified"
 ---       | "diff3_horizontal"
 ---       | "diff3_vertical"
 ---       | "diff3_mixed"
@@ -389,6 +391,7 @@ local layout_map = {
   diff1_plain = Diff1,
   diff2_horizontal = Diff2Hor,
   diff2_vertical = Diff2Ver,
+  diff_unified = DiffUnified,
   diff3_horizontal = Diff3Hor,
   diff3_vertical = Diff3Ver,
   diff3_mixed = Diff3Mixed,
@@ -576,7 +579,7 @@ function M.setup(user_config)
   do
     -- Validate layouts
     local view = M._config.view
-    local standard_layouts = { "diff2_horizontal", "diff2_vertical", -1 }
+    local standard_layouts = { "diff2_horizontal", "diff2_vertical", "diff_unified", -1 }
     local merge_layuots = {
       "diff1_plain",
       "diff3_horizontal",

--- a/lua/diffview/scene/layouts/diff_unified.lua
+++ b/lua/diffview/scene/layouts/diff_unified.lua
@@ -1,0 +1,135 @@
+local async = require("diffview.async")
+local Window = require("diffview.scene.window").Window
+local Diff2 = require("diffview.scene.layouts.diff_2").Diff2
+local oop = require("diffview.oop")
+local utils = require("diffview.utils")
+
+local api = vim.api
+local await = async.await
+
+local M = {}
+
+---@class DiffUnified : Diff2
+---@field a Window
+---@field b Window
+---@field hidden_win integer|nil
+local DiffUnified = oop.create_class("DiffUnified", Diff2)
+
+DiffUnified.name = "diff_unified"
+
+---@class DiffUnified.init.Opt
+---@field a vcs.File
+---@field b vcs.File
+---@field winid_a integer
+---@field winid_b integer
+
+---@param opt DiffUnified.init.Opt
+function DiffUnified:init(opt)
+  self:super(opt)
+end
+
+---@override
+---@param self DiffUnified
+---@param pivot integer?
+DiffUnified.create = async.void(function(self, pivot)
+  self:create_pre()
+  local a_win, b_win
+
+  pivot = pivot or self:find_pivot()
+  assert(api.nvim_win_is_valid(pivot), "Layout creation requires a valid window pivot!")
+
+  for _, win in ipairs(self.windows) do
+    if win.id ~= pivot then
+      win:close(true)
+    end
+  end
+
+  -- Create both windows - one visible and one hidden
+  api.nvim_win_call(pivot, function()
+    -- Create window 'a' as a hidden window using floating window
+    local buf = api.nvim_create_buf(false, true)
+    -- Create the window off-screen with minimal size
+    local opts = {
+      relative = 'editor',
+      width = 1,
+      height = 1,
+      row = -999, -- Position it off-screen
+      col = -999,
+      style = 'minimal',
+    }
+    a_win = api.nvim_open_win(buf, true, opts)
+    
+    if self.a then
+      self.a:set_id(a_win)
+    else
+      self.a = Window({ id = a_win })
+    end
+    
+    -- Now create the visible window that user will see
+    vim.cmd("new") -- Create the visible window for 'b'
+    b_win = api.nvim_get_current_win()
+    
+    if self.b then
+      self.b:set_id(b_win)
+    else
+      self.b = Window({ id = b_win })
+    end
+  end)
+
+  api.nvim_win_close(pivot, true)
+  self.windows = { self.a, self.b } -- Both windows needed for diff machinery
+  self.hidden_win = a_win  -- Track the hidden window
+  
+  await(self:create_post())
+end)
+
+---@override
+---@param entry FileEntry
+DiffUnified.use_entry = async.void(function(self, entry)
+  local layout = entry.layout --[[@as DiffUnified ]]
+  assert(layout:instanceof(DiffUnified))
+
+  -- Set both files to make diffview work properly
+  self:set_file_a(layout.a.file)
+  self:set_file_b(layout.b.file)
+
+  if self:is_valid() then
+    await(self:open_files())
+  end
+end)
+
+---@override
+---@param self DiffUnified
+DiffUnified.open_files = async.void(function(self)
+  -- Call the parent's open_files to set up both buffers with proper diff mode
+  await(Diff2.open_files(self))
+  
+  -- Make sure the floating window stays hidden
+  if self.hidden_win and api.nvim_win_is_valid(self.hidden_win) then
+    -- Keep the window off-screen
+    api.nvim_win_set_config(self.hidden_win, {
+      relative = 'editor',
+      row = -999,
+      col = -999,
+      width = 1,
+      height = 1,
+    })
+    
+    -- We don't need to force focus on the visible window
+    -- This was causing issues with terminal floats like lazygit
+  end
+end)
+
+---@override
+function DiffUnified:destroy()
+  -- Clean up the hidden window if it exists
+  if self.hidden_win and api.nvim_win_is_valid(self.hidden_win) then
+    pcall(api.nvim_win_close, self.hidden_win, true)
+  end
+  
+  -- Call the parent's destroy method
+  Diff2.destroy(self)
+end
+
+M.DiffUnified = DiffUnified
+return M


### PR DESCRIPTION
## Summary
- Added a new unified diff layout (diff_unified) to display file diffs in a single window
- Uses Neovim's built-in diff mode with a hidden window for proper highlighting
- Allows users to view diffs in unified view style similar to other git tools

## Test plan
1. Check that the layout can be selected with `g<C-x>`
2. Verify diff highlighting works properly
3. Test with different types of changes (additions, deletions, modifications)
4. Confirm configuration via `layout = "diff_unified"`

Related issue https://github.com/sindrets/diffview.nvim/issues/39