### PR TITLE
fix: show untracked files when comparing working tree

### DIFF
--- a/lua/diffview/vcs/adapters/git/init.lua
+++ b/lua/diffview/vcs/adapters/git/init.lua
@@ -1670,9 +1670,8 @@ function GitAdapter:show_untracked(opt)
   opt = opt or {}
 
   if opt.revs then
-    -- Never show untracked files when comparing against anything other than
-    -- the index
-    if not (opt.revs.left.type == RevType.STAGE and opt.revs.right.type == RevType.LOCAL) then
+    -- Show untracked files when comparing against the working tree (LOCAL)
+    if opt.revs.right.type ~= RevType.LOCAL then
       return false
     end
   end


### PR DESCRIPTION
> [!NOTE]
> I apologize for accidentally closing PR #585

## Summary

This PR fixes an issue where untracked files are not displayed when comparing the working tree against a specific commit using `DiffviewOpen`.

Fixes #584

## Problem

The current implementation only shows untracked files when comparing the index (stage) against the working tree (`DiffviewOpen` with no arguments). However, the documentation states:

```vim
" Diff the working tree against a specific commit:
:DiffviewOpen HEAD~2
```

When comparing the working tree against a commit, users would expect to see all changes including untracked files, but they are currently hidden.

## Solution

Modified the condition in GitAdapter:show_untracked() to check if the right side of the comparison is the working tree (LOCAL), rather than requiring both specific left (STAGE) and right (LOCAL) types.

### Before

```lua
-- Only show untracked files for STAGE..LOCAL comparison
if not (opt.revs.left.type == RevType.STAGE and opt.revs.right.type == RevType.LOCAL) then
  return false
end
```

### After

```lua
-- Show untracked files when comparing against the working tree (LOCAL)
if opt.revs.right.type ~= RevType.LOCAL then
  return false
end
```

## Testing

- DiffviewOpen - Shows untracked files (existing behavior preserved)
- DiffviewOpen HEAD~1 - Now shows untracked files
- DiffviewOpen main - Now shows untracked files
- DiffviewOpen HEAD~1 -uno - Hides untracked files as expected
- DiffviewOpen HEAD~1..HEAD - Does not show untracked files (correct, as neither side is LOCAL)

## Notes

- The -u/--untracked-files flag now works correctly for all working tree comparisons
- Users can still use -uno to hide untracked files if desired
- This change aligns the behavior with the documentation and user expectations

