### PR TITLE
feat(file-history): customize the max length of commit subject before truncating

### DIFF
--- a/doc/diffview_defaults.txt
+++ b/doc/diffview_defaults.txt
@@ -62,6 +62,7 @@ DEFAULT CONFIG                                  *diffview.defaults*
       },
     },
     file_history_panel = {
+      max_len_commit_subject = 72,
       log_options = {   -- See |diffview-config-log_options|
         git = {
           single_file = {

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -83,6 +83,7 @@ M.defaults = {
     },
   },
   file_history_panel = {
+    max_len_commit_subject = 72,
     log_options = {
       ---@type ConfigLogOptions
       git = {

--- a/lua/diffview/scene/views/file_history/render.lua
+++ b/lua/diffview/scene/views/file_history/render.lua
@@ -142,7 +142,7 @@ local function render_entries(panel, parent, entries, updating)
       comp:add_text((" (%s)"):format(entry.commit.ref_names), "DiffviewReference")
     end
 
-    local subject = utils.str_trunc(entry.commit.subject, 72)
+    local subject = utils.str_trunc(entry.commit.subject, c.file_history_panel.max_len_commit_subject)
 
     if subject == "" then
       subject = "[empty message]"


### PR DESCRIPTION
A line of 72 bytes is sometimes deemed too short. An example config is shown below:
```lua
    opts = {
      file_history_panel = {
        max_len_commit_subject = 9999,
        win_config = {
          win_opts = {
            wrap = true,
          },
        },
      },
    },
```